### PR TITLE
(pC-3345): stop the API call when infinite loop

### DIFF
--- a/src/components/pages/Offerers/Offerers.jsx
+++ b/src/components/pages/Offerers/Offerers.jsx
@@ -86,6 +86,7 @@ class Offerers extends PureComponent {
 
     const handleFail = () => {
       this.setState({
+        hasMore: false,
         isLoading: false,
       })
     }


### PR DESCRIPTION
Pour reproduire le bug, je coupe mon back et je scroll ma page vers le bas et j'avais une boucle infinie d'appel API.