### PR TITLE
(PC-4330): Display offer items as a table

### DIFF
--- a/src/components/pages/Offers/OfferItem/OfferItem.jsx
+++ b/src/components/pages/Offers/OfferItem/OfferItem.jsx
@@ -73,9 +73,11 @@ const OfferItem = ({
   const offerStatus = computeOfferStatus(offer, stocks)
 
   return (
-    <li className={`offer-item ${isOfferInactiveOrExpired ? 'inactive' : ''} offer-row`}>
-      <Thumb url={offer.thumbUrl} />
-      <div className="title-container">
+    <tr className={`offer-item ${isOfferInactiveOrExpired ? 'inactive' : ''} offer-row`}>
+      <td className="thumb-column">
+        <Thumb url={offer.thumbUrl} />
+      </td>
+      <td className="title-column">
         <Link
           className="name"
           title="Afficher le détail de l'offre"
@@ -105,35 +107,39 @@ const OfferItem = ({
             </div>
           )}
         </span>
-      </div>
-      <span>
+      </td>
+      <td className="venue-column">
         {(venue && venue.publicName) || venue.name}
-      </span>
-      <span>
+      </td>
+      <td className="stock-column">
         {computeRemainingStockValue(stocks)}
-      </span>
-      <span className="status-column">
+      </td>
+      <td className="status-column">
         <span className={OFFER_STATUS_PROPERTIES[offerStatus].className}>
           <Icon svg={OFFER_STATUS_PROPERTIES[offerStatus].icon} />
           {offerStatus}
         </span>
-      </span>
-      <button
-        className="secondary-button"
-        onClick={handleOnDeactivateClick}
-        type="button"
-      >
-        {offer.isActive ? 'Désactiver' : 'Activer'}
-      </button>
-      {isOfferEditable && (
-        <Link
-          className="secondary-link"
-          to={`/offres/${offer.id}/edition`}
+      </td>
+      <td className="switch-column">
+        <button
+          className="secondary-button"
+          onClick={handleOnDeactivateClick}
+          type="button"
         >
-          <Icon svg="ico-pen" />
-        </Link>
-      )}
-    </li>
+          {offer.isActive ? 'Désactiver' : 'Activer'}
+        </button>
+      </td>
+      <td className="edit-column">
+        {isOfferEditable && (
+          <Link
+            className="secondary-link"
+            to={`/offres/${offer.id}/edition`}
+          >
+            <Icon svg="ico-pen" />
+          </Link>
+        )}
+      </td>
+    </tr>
   )
 }
 

--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -1,7 +1,7 @@
 import { Icon, resolveIsNew } from 'pass-culture-shared'
 import PropTypes from 'prop-types'
 import { stringify } from 'query-string'
-import React, { Fragment, PureComponent } from 'react'
+import React, { PureComponent } from 'react'
 import LoadingInfiniteScroll from 'react-loading-infinite-scroller'
 import { Link } from 'react-router-dom'
 
@@ -260,21 +260,35 @@ class Offers extends PureComponent {
           )}
 
           {offers.length > 0 && (
-            <Fragment>
-              <div className="offer-row">
-                <span className="venue-title">
-                  {'Lieu'}
-                </span>
-                <span className="stock-title">
-                  {'Stock'}
-                </span>
-                <span className="status-title">
-                  {'Statut'}
-                </span>
-              </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>
+&nbsp;
+                  </th>
+                  <th>
+&nbsp;
+                  </th>
+                  <th>
+                    {'Lieu'}
+                  </th>
+                  <th>
+                    {'Stock'}
+                  </th>
+                  <th>
+                    {'Statut'}
+                  </th>
+                  <th>
+&nbsp;
+                  </th>
+                  <th>
+&nbsp;
+                  </th>
+                </tr>
+              </thead>
               <LoadingInfiniteScroll
                 className="offers-list"
-                element="ul"
+                element="tbody"
                 handlePageChange={this.onPageChange}
                 handlePageReset={this.onPageReset}
                 hasMore={hasMore}
@@ -282,13 +296,13 @@ class Offers extends PureComponent {
                 loader={<Spinner key="spinner" />}
               >
                 {offers.map(offer => (
-                  <Fragment key={offer.id}>
-                    <OfferItemContainer offer={offer} />
-                    <hr />
-                  </Fragment>
+                  <OfferItemContainer
+                    key={offer.id}
+                    offer={offer}
+                  />
                 ))}
               </LoadingInfiniteScroll>
-            </Fragment>
+            </table>
           )}
           {hasMore === false && 'Fin des résultats'}
         </div>

--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -263,12 +263,8 @@ class Offers extends PureComponent {
             <table>
               <thead>
                 <tr>
-                  <th>
-&nbsp;
-                  </th>
-                  <th>
-&nbsp;
-                  </th>
+                  <th>&nbsp;</th>
+                  <th>&nbsp;</th>
                   <th>
                     {'Lieu'}
                   </th>
@@ -278,12 +274,8 @@ class Offers extends PureComponent {
                   <th>
                     {'Statut'}
                   </th>
-                  <th>
-&nbsp;
-                  </th>
-                  <th>
-&nbsp;
-                  </th>
+                  <th>&nbsp;</th>
+                  <th>&nbsp;</th>
                 </tr>
               </thead>
               <LoadingInfiniteScroll

--- a/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
+++ b/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
@@ -122,7 +122,7 @@
   }
 
   .status-column {
-    width: rem(155px);
+    width: rem(145px);
   }
 
   .switch-column {

--- a/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
+++ b/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
@@ -10,7 +10,7 @@
   .offer-thumb,
   .default-thumb {
     height: rem(84px);
-    width: 100%;
+    width: rem(82px);
   }
 
   &.inactive {
@@ -106,6 +106,36 @@
       flex-shrink: 0;
       max-height: rem(16px);
       max-width: rem(16px);
+    }
+  }
+
+  .thumb-column {
+    width: rem(82px);
+  }
+
+  .title-column {
+    width: rem(185px);
+  }
+
+  .venue-column {
+    width: rem(135px);
+  }
+
+  .status-column {
+    width: rem(155px);
+  }
+
+  .switch-column {
+    width: 6rem;
+    button {
+      width: rem(96px);
+    }
+  }
+
+  .edit-column {
+    width: rem(40px);
+    a {
+      width: rem(40px);
     }
   }
 }

--- a/src/styles/components/pages/Offers/_Offers.scss
+++ b/src/styles/components/pages/Offers/_Offers.scss
@@ -66,27 +66,39 @@
     }
   }
 
-  .offer-row {
-    align-items: center;
-    display: grid;
-    grid-column-gap: rem(16px);
-    grid-template-columns: rem(82px) 4fr 3fr rem(70px) rem(110px) rem(96px) rem(40px);
-  }
+  table {
+    width: 100%;
 
-  .venue-title,
-  .stock-title,
-  .status-title {
-    @include caption();
-  }
+    th {
+      @include caption();
+      padding: 0 rem(8px);
+    }
 
-  .venue-title {
-    grid-column-start: 3;
-  }
+    tbody > tr {
+      border-bottom: 1px solid $grey-medium;
 
-  hr {
-    background: none;
-    border-top: 1px solid $grey-medium;
-    grid-column: 1/7;
-    margin: rem(16px) 0;
+      td {
+        padding: rem(16px) rem(8px);
+        vertical-align: middle;
+      }
+
+      td:last-child {
+        padding-right: 0;
+      }
+
+      td:first-child {
+        padding-left: 0;
+      }
+
+      &:first-child {
+        td {
+          padding-top: 0;
+        }
+      }
+
+      &:last-child {
+        border: none;
+      }
+    }
   }
 }

--- a/src/styles/components/pages/Offers/_Offers.scss
+++ b/src/styles/components/pages/Offers/_Offers.scss
@@ -71,6 +71,7 @@
 
     th {
       @include caption();
+
       padding: 0 rem(8px);
     }
 

--- a/testcafe/06_offers.js
+++ b/testcafe/06_offers.js
@@ -24,7 +24,7 @@ test('j’ai accès à l’ensemble de mes offres', async t => {
     'pro_06_offers',
     'get_existing_pro_validated_user_with_at_least_one_visible_activated_offer'
   )
-  const offerItem = Selector('li.offer-item')
+  const offerItem = Selector('.offer-item')
   await navigateToOffersAs(user)(t)
 
   await t

--- a/testcafe/helpers/navigations.js
+++ b/testcafe/helpers/navigations.js
@@ -104,7 +104,7 @@ export const navigateToNewOfferAs = (user, offerer, venue, userRole) => async t 
 export const navigateToOfferAs = (user, offer, userRole) => async t => {
   const searchInput = Selector('#search')
   const submitButton = Selector('button[type="submit"]')
-  const offerAnchor = Selector('li.offer-item').find(`a[href^="/offres/${offer.id}"]`)
+  const offerAnchor = Selector(`a[href^="/offres/${offer.id}"]`)
 
   if (!userRole) {
     await t.useRole(createUserRole(user))


### PR DESCRIPTION
Cette PR est associée au ticket 4330 et non 4252.

Le but est de transformer le display actuel des Offers en table plutôt qu'en liste.