### PR TITLE
Mob extract layout from main with router

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -7,7 +7,7 @@ import AppContainer from 'app/AppContainer'
 import NoMatchPage from 'components/pages/NoMatch/NoMatch'
 import MatomoContainer from 'components/matomo/MatomoContainer'
 import FeaturedRouteContainer from 'components/router/FeaturedRouteContainer'
-import routes from 'utils/routes_map'
+import routes, { routesWithMain } from 'utils/routes_map'
 import configureStore from 'store'
 
 const { store, persistor } = configureStore()
@@ -23,7 +23,7 @@ const Root = () => {
           <BrowserRouter>
             <AppContainer>
               <Switch>
-                {routes.map(route => {
+                {[...routes, ...routesWithMain].map(route => {
                   const isExact = typeof route.exact !== 'undefined' ? route.exact : true
                   // first props, last overrides
                   return (

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,12 +1,118 @@
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { Fragment } from 'react'
+import { matchCurrentRoute } from 'utils/routes_map'
+import { NavLink } from 'react-router-dom'
+import ReactTooltip from 'react-tooltip'
+
+import { Icon, Modal, Spinner } from 'pass-culture-shared'
+
+import HeaderContainer from 'components/layout/Header/HeaderContainer'
+import NotificationContainer from 'components/layout/Notification/NotificationContainer'
+
 import RedirectToMaintenance from './RedirectToMaintenance'
 
-export const App = ({ modalOpen, isMaintenanceActivated, children }) => {
+const getLayoutConfig = pathname => {
+  const defaultConfig = {
+    loading: false,
+    backTo: null,
+    fullscreen: false,
+    header: {},
+    pageName: 'Acceuil',
+    redBg: false, // FIXME (rlecellier): this is never used !
+    withLayout: false,
+    whiteHeader: true,
+    withLoading: false, // FIXME (rlecellier): this is never used !
+  }
+
+  const match = matchCurrentRoute(pathname)
+  return { ...defaultConfig, ...match.layoutConfig }
+}
+
+export const App = props => {
+  const { children, isMaintenanceActivated, location, modalOpen } = props
+
+  const {
+    backTo,
+    fullscreen,
+    header,
+    pageName,
+    whiteHeader,
+    withLayout,
+    withLoading,
+    loading,
+  } = getLayoutConfig(location.pathname)
+
   if (isMaintenanceActivated) {
     return <RedirectToMaintenance />
-  } else return (
+  }
+
+  if (withLayout) {
+    return (
+      <div className={classnames('app', { 'modal-open': modalOpen })}>
+        {!fullscreen && (
+          <HeaderContainer
+            whiteHeader={whiteHeader}
+            {...header}
+          />
+        )}
+        <ReactTooltip
+          className="flex-center items-center"
+          delayHide={500}
+          effect="solid"
+          html
+        />
+
+        <main
+          className={classnames({
+            page: true,
+            [`${pageName}-page`]: true,
+            'with-header': Boolean(header),
+            'white-header': whiteHeader,
+            container: !fullscreen,
+            fullscreen,
+            loading,
+          })}
+        >
+          {fullscreen ? (
+            <Fragment>
+              <NotificationContainer isFullscreen />
+              {children}
+            </Fragment>
+          ) : (
+            <div className="columns is-gapless">
+              <div className="page-content column is-10 is-offset-1">
+                <NotificationContainer />
+                <div
+                  className={classnames('after-notification-content', {
+                    'with-padding': backTo,
+                  })}
+                >
+                  {backTo && (
+                    <NavLink
+                      className="back-button has-text-primary has-text-weight-semibold"
+                      to={backTo.path}
+                    >
+                      <Icon svg="ico-back" />
+                      {` ${backTo.label}`}
+                    </NavLink>
+                  )}
+                  <div className="main-content">
+                    {children}
+                  </div>
+                  {withLoading && loading && <Spinner />}
+                </div>
+              </div>
+            </div>
+          )}
+        </main>
+
+        <Modal key="modal" />
+      </div>
+    )
+  }
+
+  return (
     <div className={classnames('app', { 'modal-open': modalOpen })}>
       {children}
     </div>

--- a/src/components/pages/Home/Home.jsx
+++ b/src/components/pages/Home/Home.jsx
@@ -1,13 +1,9 @@
 import React from 'react'
 
 import Card from './Card/Card'
-import Main from '../../layout/Main'
 
-const Home = () => (
-  <Main
-    name="home"
-    whiteHeader
-  >
+const Home = () => {
+  return (
     <div className="home-cards columns">
       <Card
         navLink="/guichet"
@@ -22,7 +18,7 @@ const Home = () => (
         title="Offres"
       />
     </div>
-  </Main>
-)
+  )
+}
 
 export default Home

--- a/src/store/selectors/data/usersSelectors.js
+++ b/src/store/selectors/data/usersSelectors.js
@@ -6,6 +6,9 @@ export const selectCurrentUser = createSelector(
     if (users && users.length > 0) {
       return users[0]
     }
+    return {
+      publicName: 'Visitor',
+    }
   }
 )
 
@@ -16,12 +19,9 @@ export const resolveCurrentUser = userFromRequest => {
   return userFromRequest
 }
 
-export const selectIsUserAdmin = createSelector(
-  selectCurrentUser,
-  currentUser => {
-    if (!currentUser) {
-      return false
-    }
-    return currentUser.isAdmin
+export const selectIsUserAdmin = createSelector(selectCurrentUser, currentUser => {
+  if (!currentUser) {
+    return false
   }
-)
+  return currentUser.isAdmin
+})

--- a/src/utils/routes_map.jsx
+++ b/src/utils/routes_map.jsx
@@ -1,166 +1,218 @@
 import React from 'react'
-import { Redirect } from 'react-router'
-import BookingsRecapContainer from '../components/pages/Bookings/BookingsRecapContainer'
-import CsvDetailViewContainer from '../components/layout/CsvTable/CsvTableContainer'
-import DeskContainer from '../components/pages/Desk/DeskContainer'
-import HomeContainer from '../components/pages/Home/HomeContainer'
-import LostPasswordContainer from '../components/pages/LostPassword/LostPasswordContainer'
-import Mediation from '../components/pages/Mediation/MediationContainer'
-import Offers from '../components/pages/Offers/OffersContainer'
-import OfferCreation from '../components/pages/Offer/OfferCreation/OfferCreationContainer'
-import OfferEdition from '../components/pages/Offer/OfferEdition/OfferEditionContainer'
-import Offerers from '../components/pages/Offerers/OfferersContainer'
-import OffererCreationContainer from '../components/pages/Offerer/OffererCreation/OffererCreationContainer'
-import OffererDetailsContainer from '../components/pages/Offerer/OffererDetails/OffererDetailsContainer'
-import ProfilContainer from '../components/pages/Profil/ProfilContainer'
-import ReimbursementsContainer from '../components/pages/Reimbursements/ReimbursementsContainer'
-import SigninContainer from '../components/pages/Signin/SigninContainer'
-import SignupContainer from '../components/pages/Signup/SignupContainer'
-import SignupValidationContainer from '../components/pages/Signup/SignupValidation/SignupValidationContainer'
-import VenueCreationContainer from '../components/pages/Venue/VenueCreation/VenueCreationContainer'
-import VenueEditionContainer from '../components/pages/Venue/VenueEdition/VenueEditionContainer'
-import Unavailable from '../components/pages/Errors/Unavailable/Unavailable'
+import { Redirect, matchPath } from 'react-router'
+
+import BookingsRecapContainer from 'components/pages/Bookings/BookingsRecapContainer'
+import CsvDetailViewContainer from 'components/layout/CsvTable/CsvTableContainer'
+import DeskContainer from 'components/pages/Desk/DeskContainer'
+import HomeContainer from 'components/pages/Home/HomeContainer'
+import LostPasswordContainer from 'components/pages/LostPassword/LostPasswordContainer'
+import Mediation from 'components/pages/Mediation/MediationContainer'
+import Offers from 'components/pages/Offers/OffersContainer'
+import OfferCreation from 'components/pages/Offer/OfferCreation/OfferCreationContainer'
+import OfferEdition from 'components/pages/Offer/OfferEdition/OfferEditionContainer'
+import Offerers from 'components/pages/Offerers/OfferersContainer'
+import OffererCreationContainer from 'components/pages/Offerer/OffererCreation/OffererCreationContainer'
+import OffererDetailsContainer from 'components/pages/Offerer/OffererDetails/OffererDetailsContainer'
+import ProfilContainer from 'components/pages/Profil/ProfilContainer'
+import ReimbursementsContainer from 'components/pages/Reimbursements/ReimbursementsContainer'
+import SigninContainer from 'components/pages/Signin/SigninContainer'
+import SignupContainer from 'components/pages/Signup/SignupContainer'
+import SignupValidationContainer from 'components/pages/Signup/SignupValidation/SignupValidationContainer'
+import VenueCreationContainer from 'components/pages/Venue/VenueCreation/VenueCreationContainer'
+import VenueEditionContainer from 'components/pages/Venue/VenueEdition/VenueEditionContainer'
+import Unavailable from 'components/pages/Errors/Unavailable/Unavailable'
+import StyleguideContainer from 'components/pages/Styleguide/StyleguideContainer'
+
 import { UNAVAILABLE_ERROR_PAGE } from './routes'
-import StyleguideContainer from '../components/pages/Styleguide/StyleguideContainer'
 
 const RedirectToConnexionComponent = () => <Redirect to="/connexion" />
 
 // NOTE: routes are sorted by PATH alphabetical order
-const routes = [
+// DEPRECATED: Pages are currently be rework to not use <Main> component
+export const routesWithMain = [
   {
     component: RedirectToConnexionComponent,
+    exact: true,
     path: '/',
   },
   {
-    component: HomeContainer,
-    path: '/accueil',
-    title: 'Accueil',
-  },
-  {
     component: SigninContainer,
+    exact: true,
     path: '/connexion',
     title: 'Connexion',
   },
   {
     component: DeskContainer,
+    exact: true,
     path: '/guichet',
     title: 'Guichet',
   },
   {
     component: SignupContainer,
+    exact: true,
     path: '/inscription/(confirmation)?',
     title: 'Inscription',
   },
   {
     component: SignupValidationContainer,
+    exact: true,
     path: '/inscription/validation/:token',
     title: 'Validation de votre inscription',
   },
   {
     component: LostPasswordContainer,
+    exact: true,
     path: '/mot-de-passe-perdu',
     title: 'Mot de passe perdu',
   },
   {
     component: Offerers,
+    exact: true,
     path: '/structures',
     title: 'Structures',
   },
   {
     component: OffererCreationContainer,
+    exact: true,
     path: '/structures/creation',
     title: 'Structure',
   },
   {
     component: OffererDetailsContainer,
+    exact: true,
     path: '/structures/:offererId',
     title: 'Structure',
   },
   {
     component: VenueCreationContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/creation',
     title: 'Lieu',
   },
   {
     component: VenueEditionContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/modification',
     title: 'Lieu',
   },
   {
     component: VenueEditionContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId',
     title: 'Lieu',
   },
   {
     component: Offers,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/offres',
     title: 'Offres',
   },
   {
     component: ReimbursementsContainer,
+    exact: true,
     path: '/remboursements',
     title: 'Remboursements',
   },
   {
     component: BookingsRecapContainer,
+    exact: true,
     path: '/reservations',
     title: 'Réservations',
   },
   {
     component: Offers,
+    exact: true,
     path: '/offres',
     title: 'Offres',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/offres/:offerId',
     title: 'Offre',
   },
   {
     component: OfferEdition,
+    exact: true,
     path: '/offres/:offerId/edition',
     title: "Edition d'une offre",
   },
   {
     component: Mediation,
+    exact: true,
     path: '/offres/:offerId/accroches/:mediationId',
     title: 'Accroche',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/structures/:offererId/offres/:offerId',
     title: 'Offres',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/offres/:offerId',
     title: 'Offres',
   },
   {
     component: ProfilContainer,
+    exact: true,
     path: '/profil',
     title: 'Profil',
   },
   {
     component: CsvDetailViewContainer,
+    exact: true,
     path: '/reservations/detail',
     title: 'Réservations',
   },
   {
     component: CsvDetailViewContainer,
+    exact: true,
     path: '/remboursements/detail',
     title: 'Remboursements',
   },
   {
     component: StyleguideContainer,
+    exact: true,
     path: '/styleguide',
     title: 'Styleguide',
   },
   {
     component: Unavailable,
+    exact: true,
     path: UNAVAILABLE_ERROR_PAGE,
     title: 'Page indisponible',
   },
 ]
+
+// Routes that does not use <Main> and are now functional components
+const routes = [
+  {
+    component: HomeContainer,
+    exact: true,
+    path: '/accueil',
+    title: 'Accueil',
+    layoutConfig: {
+      whiteHeader: true,
+    },
+  },
+]
+
+export const matchCurrentRoute = pathname => {
+  let match = routes.find(route => {
+    return !!matchPath(pathname, route)
+  })
+  if (match) {
+    match = { ...match }
+    match.layoutConfig.withLayout = true
+    return match
+  }
+
+  return routesWithMain.find(route => {
+    return !!matchPath(pathname, route)
+  })
+}
 
 export default routes


### PR DESCRIPTION
 `routes_map` contient maintenant 2 tableaux de routes:
* routeWithMain qui contient les route utilisant le composant `Main`
* routes qui contient les route utilisant le layout de `App`

le layout est configurable (couleur du header, url du bouton back, etc) via le paramétre `layoutConfig` dans la définition de la route.

**todo:**
* fixer les test sur le users qui est maintenant chargé apres le render du layout. (retiré withLogin comme prérequis ?)
* s'assurer que `exact: true` ne casse pas la navigation
* retirer les paramètres non utilisées de layoutConfig (par example: redBg, withLoading, loading)

**la suite:**
* migrer une route utilisant un class component en lui intégrant sont cycle de vie va les hook react.