### PR TITLE
MediationsManagerContainer: remove usage of withRoute

### DIFF
--- a/src/components/pages/Offer/MediationsManager/MediationsManagerContainer.js
+++ b/src/components/pages/Offer/MediationsManager/MediationsManagerContainer.js
@@ -1,17 +1,11 @@
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router'
-import { compose } from 'redux'
 
 import MediationsManager from './MediationsManager'
 import { selectMediationsByOfferId } from 'store/selectors/data/mediationsSelectors'
 import { selectOfferById } from 'store/selectors/data/offersSelectors'
 
 export const mapStateToProps = (state, ownProps) => {
-  const {
-    match: {
-      params: { offerId },
-    },
-  } = ownProps
+  const { offerId } = ownProps
   const mediations = selectMediationsByOfferId(state, offerId)
 
   return {
@@ -23,4 +17,4 @@ export const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default compose(withRouter, connect(mapStateToProps))(MediationsManager)
+export default connect(mapStateToProps)(MediationsManager)

--- a/src/components/pages/Offer/MediationsManager/__specs__/MediationsManagerContainer.spec.js
+++ b/src/components/pages/Offer/MediationsManager/__specs__/MediationsManagerContainer.spec.js
@@ -6,11 +6,7 @@ describe('src | MediationsMananagerContainer', () => {
     it('should return an object of props', () => {
       // given
       const props = {
-        match: {
-          params: {
-            offerId: 'UU',
-          },
-        },
+        offerId: 'UU',
       }
 
       // when

--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -540,7 +540,7 @@ class OfferCreation extends PureComponent {
               providerName={offer.lastProvider.name.toLowerCase()}
             />
           )}
-          {!isCreatedEntity && offer && <MediationsManager />}
+          {!isCreatedEntity && offer && <MediationsManager offerId={offer.id} />}
 
           {showAllForm && (
             <div>

--- a/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
+++ b/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
@@ -469,7 +469,7 @@ class OfferEdition extends PureComponent {
               providerName={offer.lastProvider.name.toLowerCase()}
             />
           )}
-          {offer && <MediationsManager />}
+          {offer && <MediationsManager offerId={offer.id} />}
 
           {showAllForm && (
             <div>


### PR DESCRIPTION
Les modifications faite dans : https://github.com/pass-culture/pass-culture-pro/pull/730 rendent la configuration des test plus compliqué.
En retirant withRouter de ce composants, tout devient plus facile.