### PR TITLE
(PC-5428) App: add layout

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -4,11 +4,12 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 
 import AppContainer from 'app/AppContainer'
+import AppLayout from 'app/AppLayout'
 import MatomoContainer from 'components/matomo/MatomoContainer'
 import NoMatchPage from 'components/pages/NoMatch/NoMatch'
 import FeaturedRouteContainer from 'components/router/FeaturedRouteContainer'
 import configureStore from 'store'
-import routes from 'utils/routes_map'
+import routes, { routesWithMain } from 'utils/routes_map'
 
 const { store, persistor } = configureStore()
 
@@ -24,12 +25,25 @@ const Root = () => {
             <AppContainer>
               <Switch>
                 {routes.map(route => {
-                  const isExact = typeof route.exact !== 'undefined' ? route.exact : true
+                  return (
+                    <FeaturedRouteContainer
+                      exact={route.exact}
+                      key={route.path}
+                      path={route.path}
+                    >
+                      <AppLayout layoutConfig={route.meta && route.meta.layoutConfig}>
+                        <route.component />
+                      </AppLayout>
+                    </FeaturedRouteContainer>
+                  )
+                })}
+
+                {routesWithMain.map(route => {
                   // first props, last overrides
                   return (
                     <FeaturedRouteContainer
                       {...route}
-                      exact={isExact}
+                      exact={route.exact}
                       key={route.path}
                     />
                   )

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from 'react'
 import { matchPath } from 'react-router'
 
 import Spinner from 'components/layout/Spinner'
-import routes from 'utils/routes_map'
+import routes, { routesWithMain } from 'utils/routes_map'
 
 import RedirectToMaintenance from './RedirectToMaintenance'
 
@@ -21,7 +21,9 @@ export const App = props => {
 
   const [isBusy, setIsBusy] = useState(false)
   useEffect(() => {
-    const publicRouteList = routes.filter(route => route.meta && route.meta.public)
+    const publicRouteList = [...routes, ...routesWithMain].filter(
+      route => route.meta && route.meta.public
+    )
     const isPublicRoute = !!publicRouteList.find(route =>
       matchPath(window.location.pathname, route)
     )

--- a/src/app/AppLayout.jsx
+++ b/src/app/AppLayout.jsx
@@ -1,0 +1,108 @@
+import classnames from 'classnames'
+import { Modal } from 'pass-culture-shared'
+import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
+import { NavLink } from 'react-router-dom'
+import ReactTooltip from 'react-tooltip'
+
+import ActionsBar from 'components/layout/ActionsBar'
+import HeaderContainer from 'components/layout/Header/HeaderContainer'
+import Icon from 'components/layout/Icon'
+import NotificationV1Container from 'components/layout/NotificationV1/NotificationV1Container'
+import NotificationV2Container from 'components/layout/NotificationV2/NotificationV2Container'
+
+const AppLayout = props => {
+  const { PageActionsBar, children, layoutConfig } = props
+
+  const defaultConfig = {
+    backTo: null,
+    fullscreen: false,
+    header: {},
+    pageName: 'Acceuil',
+    whiteHeader: true,
+  }
+
+  const { backTo, fullscreen, header, pageName, whiteHeader } = {
+    ...defaultConfig,
+    ...layoutConfig,
+  }
+
+  return (
+    <div>
+      {!fullscreen && (
+        <HeaderContainer
+          whiteHeader={whiteHeader}
+          {...header}
+        />
+      )}
+
+      <ReactTooltip
+        className="flex-center items-center"
+        delayHide={500}
+        effect="solid"
+        html
+      />
+
+      <main
+        className={classnames({
+          page: true,
+          [`${pageName}-page`]: true,
+          'with-header': Boolean(header),
+          'white-header': whiteHeader,
+          container: !fullscreen,
+          fullscreen,
+        })}
+      >
+        {fullscreen ? (
+          <Fragment>
+            <NotificationV1Container isFullscreen />
+            {children}
+          </Fragment>
+        ) : (
+          <div className="columns is-gapless">
+            <div className="page-content column is-10 is-offset-1">
+              <NotificationV1Container />
+              <div
+                className={classnames('after-notification-content', {
+                  'with-padding': backTo,
+                })}
+              >
+                {backTo && (
+                  <NavLink
+                    className="back-button has-text-primary has-text-weight-semibold"
+                    to={backTo.path}
+                  >
+                    <Icon svg="ico-back" />
+                    {` ${backTo.label}`}
+                  </NavLink>
+                )}
+                <div className="main-content">
+                  {children}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        <NotificationV2Container />
+        <Modal key="modal" />
+        {PageActionsBar && (
+          <ActionsBar>
+            <PageActionsBar />
+          </ActionsBar>
+        )}
+      </main>
+    </div>
+  )
+}
+
+AppLayout.defaultProps = {
+  layoutConfig: {},
+}
+
+AppLayout.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.shape()), PropTypes.shape()])
+    .isRequired,
+  layoutConfig: PropTypes.shape(),
+}
+
+export default AppLayout

--- a/src/components/pages/Home/Home.jsx
+++ b/src/components/pages/Home/Home.jsx
@@ -1,31 +1,25 @@
 import React from 'react'
 
-import Main from 'components/layout/Main'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 
 import Card from './Card/Card'
 
 const Home = () => (
-  <Main
-    name="home"
-    whiteHeader
-  >
-    <PageTitle title="Accueil" />
-    <div className="home-cards columns">
-      <Card
-        navLink="/guichet"
-        svg="ico-guichet-w"
-        text="Enregistrez les codes de réservation des porteurs du Pass."
-        title="Guichet"
-      />
-      <Card
-        navLink="/offres"
-        svg="ico-offres-w"
-        text="Créez et mettez en avant vos offres présentes sur le Pass."
-        title="Offres"
-      />
-    </div>
-  </Main>
+  <div className="home-cards columns">
+  <PageTitle title="Accueil" />
+    <Card
+      navLink="/guichet"
+      svg="ico-guichet-w"
+      text="Enregistrez les codes de réservation des porteurs du Pass."
+      title="Guichet"
+    />
+    <Card
+      navLink="/offres"
+      svg="ico-offres-w"
+      text="Créez et mettez en avant vos offres présentes sur le Pass."
+      title="Offres"
+    />
+  </div>
 )
 
 export default Home

--- a/src/components/pages/Home/__specs__/Home.spec.jsx
+++ b/src/components/pages/Home/__specs__/Home.spec.jsx
@@ -1,36 +1,22 @@
-import { shallow } from 'enzyme'
+import { render, within } from '@testing-library/react'
 import React from 'react'
+import { MemoryRouter } from 'react-router'
 
-import Main from 'components/layout/Main'
-
-import Card from '../Card/Card'
 import Home from '../Home'
 
 describe('src | components | Home', () => {
-  it('should render two Cards', () => {
+  it('should render two Cards', async () => {
     // when
-    const wrapper = shallow(<Home />)
+    render(
+      <MemoryRouter>
+        <Home />
+      </MemoryRouter>
+    )
 
     // then
-    const mainComponent = wrapper.find(Main)
-    const cards = wrapper.find(Card)
-
-    expect(mainComponent).toHaveLength(1)
-    expect(mainComponent.prop('name')).toStrictEqual('home')
-    expect(mainComponent.prop('whiteHeader')).toStrictEqual(true)
-
-    expect(cards).toHaveLength(2)
-    expect(cards.at(0).props()).toStrictEqual({
-      navLink: '/guichet',
-      svg: 'ico-guichet-w',
-      text: 'Enregistrez les codes de réservation des porteurs du Pass.',
-      title: 'Guichet',
-    })
-    expect(cards.at(1).props()).toStrictEqual({
-      navLink: '/offres',
-      svg: 'ico-offres-w',
-      text: 'Créez et mettez en avant vos offres présentes sur le Pass.',
-      title: 'Offres',
-    })
+    const deskLink = within(document.querySelector('a[href="/guichet"]')).queryAllByText(/guichet/i)
+    const offersLink = within(document.querySelector('a[href="/offres"]')).queryAllByText(/offres/i)
+    expect(deskLink).not.toBeNull()
+    expect(offersLink).not.toBeNull()
   })
 })

--- a/src/components/router/FeaturedRoute.jsx
+++ b/src/components/router/FeaturedRoute.jsx
@@ -16,7 +16,7 @@ class FeaturedRoute extends PureComponent {
   }
 
   render() {
-    const { areFeaturesLoaded, isRouteDisabled, ...routeProps } = this.props
+    const { areFeaturesLoaded, isRouteDisabled, children, ...routeProps } = this.props
     const { path } = routeProps
 
     if (!areFeaturesLoaded) {
@@ -31,8 +31,11 @@ class FeaturedRoute extends PureComponent {
         />
       )
     }
-
-    return <Route {...routeProps} />
+    return (
+      <Route {...routeProps}>
+        {children || null}
+      </Route>
+    )
   }
 }
 

--- a/src/store/selectors/data/usersSelectors.js
+++ b/src/store/selectors/data/usersSelectors.js
@@ -16,12 +16,9 @@ export const resolveCurrentUser = userFromRequest => {
   return userFromRequest
 }
 
-export const selectIsUserAdmin = createSelector(
-  selectCurrentUser,
-  currentUser => {
-    if (!currentUser) {
-      return false
-    }
-    return currentUser.isAdmin
+export const selectIsUserAdmin = createSelector(selectCurrentUser, currentUser => {
+  if (!currentUser) {
+    return false
   }
-)
+  return currentUser.isAdmin
+})

--- a/src/utils/routes_map.jsx
+++ b/src/utils/routes_map.jsx
@@ -1,45 +1,43 @@
 import React from 'react'
 import { Redirect } from 'react-router'
 
-import CsvDetailViewContainer from '../components/layout/CsvTable/CsvTableContainer'
-import BookingsRecapContainer from '../components/pages/Bookings/BookingsRecapContainer'
-import DeskContainer from '../components/pages/Desk/DeskContainer'
-import Unavailable from '../components/pages/Errors/Unavailable/Unavailable'
-import HomeContainer from '../components/pages/Home/HomeContainer'
-import LostPasswordContainer from '../components/pages/LostPassword/LostPasswordContainer'
-import Mediation from '../components/pages/Mediation/MediationContainer'
-import OfferCreation from '../components/pages/Offer/OfferCreation/OfferCreationContainer'
-import OfferEdition from '../components/pages/Offer/OfferEdition/OfferEditionContainer'
-import OffererCreationContainer from '../components/pages/Offerer/OffererCreation/OffererCreationContainer'
-import OffererDetailsContainer from '../components/pages/Offerer/OffererDetails/OffererDetailsContainer'
-import Offerers from '../components/pages/Offerers/OfferersContainer'
-import Offers from '../components/pages/Offers/OffersContainer'
-import ProfilContainer from '../components/pages/Profil/ProfilContainer'
-import ReimbursementsContainer from '../components/pages/Reimbursements/ReimbursementsContainer'
-import SigninContainer from '../components/pages/Signin/SigninContainer'
-import SignupContainer from '../components/pages/Signup/SignupContainer'
-import SignupValidationContainer from '../components/pages/Signup/SignupValidation/SignupValidationContainer'
-import StyleguideContainer from '../components/pages/Styleguide/StyleguideContainer'
-import VenueCreationContainer from '../components/pages/Venue/VenueCreation/VenueCreationContainer'
-import VenueEditionContainer from '../components/pages/Venue/VenueEdition/VenueEditionContainer'
+import CsvDetailViewContainer from 'components/layout/CsvTable/CsvTableContainer'
+import BookingsRecapContainer from 'components/pages/Bookings/BookingsRecapContainer'
+import DeskContainer from 'components/pages/Desk/DeskContainer'
+import Unavailable from 'components/pages/Errors/Unavailable/Unavailable'
+import HomeContainer from 'components/pages/Home/HomeContainer'
+import LostPasswordContainer from 'components/pages/LostPassword/LostPasswordContainer'
+import Mediation from 'components/pages/Mediation/MediationContainer'
+import OfferCreation from 'components/pages/Offer/OfferCreation/OfferCreationContainer'
+import OfferEdition from 'components/pages/Offer/OfferEdition/OfferEditionContainer'
+import OffererCreationContainer from 'components/pages/Offerer/OffererCreation/OffererCreationContainer'
+import OffererDetailsContainer from 'components/pages/Offerer/OffererDetails/OffererDetailsContainer'
+import Offerers from 'components/pages/Offerers/OfferersContainer'
+import Offers from 'components/pages/Offers/OffersContainer'
+import ProfilContainer from 'components/pages/Profil/ProfilContainer'
+import ReimbursementsContainer from 'components/pages/Reimbursements/ReimbursementsContainer'
+import SigninContainer from 'components/pages/Signin/SigninContainer'
+import SignupContainer from 'components/pages/Signup/SignupContainer'
+import SignupValidationContainer from 'components/pages/Signup/SignupValidation/SignupValidationContainer'
+import StyleguideContainer from 'components/pages/Styleguide/StyleguideContainer'
+import VenueCreationContainer from 'components/pages/Venue/VenueCreation/VenueCreationContainer'
+import VenueEditionContainer from 'components/pages/Venue/VenueEdition/VenueEditionContainer'
 
 import { UNAVAILABLE_ERROR_PAGE } from './routes'
 
 const RedirectToConnexionComponent = () => <Redirect to="/connexion" />
 
 // NOTE: routes are sorted by PATH alphabetical order
-const routes = [
+// DEPRECATED: Pages are currently be rework to not use <Main> component
+export const routesWithMain = [
   {
     component: RedirectToConnexionComponent,
+    exact: true,
     path: '/',
   },
   {
-    component: HomeContainer,
-    path: '/accueil',
-    title: 'Accueil',
-  },
-  {
     component: SigninContainer,
+    exact: true,
     path: '/connexion',
     title: 'Connexion',
     meta: {
@@ -48,11 +46,13 @@ const routes = [
   },
   {
     component: DeskContainer,
+    exact: true,
     path: '/guichet',
     title: 'Guichet',
   },
   {
     component: SignupContainer,
+    exact: true,
     path: '/inscription/(confirmation)?',
     title: 'Inscription',
     meta: {
@@ -61,6 +61,7 @@ const routes = [
   },
   {
     component: SignupValidationContainer,
+    exact: true,
     path: '/inscription/validation/:token',
     title: 'Validation de votre inscription',
     meta: {
@@ -69,6 +70,7 @@ const routes = [
   },
   {
     component: LostPasswordContainer,
+    exact: true,
     path: '/mot-de-passe-perdu',
     title: 'Mot de passe perdu',
     meta: {
@@ -77,105 +79,140 @@ const routes = [
   },
   {
     component: Offerers,
+    exact: true,
     path: '/structures',
     title: 'Structures',
   },
   {
     component: OffererCreationContainer,
+    exact: true,
     path: '/structures/creation',
     title: 'Structure',
   },
   {
     component: OffererDetailsContainer,
+    exact: true,
     path: '/structures/:offererId',
     title: 'Structure',
   },
   {
     component: VenueCreationContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/creation',
     title: 'Lieu',
   },
   {
     component: VenueEditionContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/modification',
     title: 'Lieu',
   },
   {
     component: VenueEditionContainer,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId',
     title: 'Lieu',
   },
   {
     component: Offers,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/offres',
     title: 'Offres',
   },
   {
     component: ReimbursementsContainer,
+    exact: true,
     path: '/remboursements',
     title: 'Remboursements',
   },
   {
     component: BookingsRecapContainer,
+    exact: true,
     path: '/reservations',
     title: 'Réservations',
   },
   {
     component: Offers,
+    exact: true,
     path: '/offres',
     title: 'Offres',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/offres/:offerId',
     title: 'Offre',
   },
   {
     component: OfferEdition,
+    exact: true,
     path: '/offres/:offerId/edition',
     title: "Edition d'une offre",
   },
   {
     component: Mediation,
+    exact: true,
     path: '/offres/:offerId/accroches/:mediationId',
     title: 'Accroche',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/structures/:offererId/offres/:offerId',
     title: 'Offres',
   },
   {
     component: OfferCreation,
+    exact: true,
     path: '/structures/:offererId/lieux/:venueId/offres/:offerId',
     title: 'Offres',
   },
   {
     component: ProfilContainer,
+    exact: true,
     path: '/profil',
     title: 'Profil',
   },
   {
     component: CsvDetailViewContainer,
+    exact: true,
     path: '/reservations/detail',
     title: 'Réservations',
   },
   {
     component: CsvDetailViewContainer,
+    exact: true,
     path: '/remboursements/detail',
     title: 'Remboursements',
   },
   {
     component: StyleguideContainer,
+    exact: true,
     path: '/styleguide',
     title: 'Styleguide',
   },
   {
     component: Unavailable,
+    exact: true,
     path: UNAVAILABLE_ERROR_PAGE,
     title: 'Page indisponible',
     meta: {
       public: true,
+    },
+  },
+]
+
+// Routes that does not use <Main> and are now functional components
+const routes = [
+  {
+    component: HomeContainer,
+    exact: true,
+    path: '/accueil',
+    title: 'Accueil',
+    meta: {
+      layoutConfig: {
+        whiteHeader: true,
+      },
     },
   },
 ]


### PR DESCRIPTION
 `routes_map` contient maintenant 2 tableaux de routes:
* routeWithMain qui contient les route utilisant le composant `Main`
* routes qui contient les route utilisant le layout de `App`

le layout est configurable (couleur du header, url du bouton back, etc) via le paramétre `layoutConfig` dans la définition de la route.
