### PR TITLE
Increase webpack bundle size in production

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -62,7 +62,7 @@ module.exports = {
       Path.relative(Paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/'),
   },
   performance: {
-    maxAssetSize: 2000000,
+    maxAssetSize: 2500000,
     maxEntrypointSize: 3000000,
   },
   resolve: {


### PR DESCRIPTION
  Since dependencies ugrade (patch and minors) the bundle size is bigger
than 2MB. Increase it to 2.5MB.