### PR TITLE
(PC-4272): fix non duo offer creation

### DIFF
--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -270,9 +270,12 @@ class OfferCreation extends PureComponent {
     if (!isCreatedEntity) return
 
     const isEventType = get(selectedOfferType, 'type') === 'Event'
-    if (!isEventType) return
 
-    updateFormSetIsDuo(true)
+    if (isEventType) {
+      updateFormSetIsDuo(true)
+    } else {
+      updateFormSetIsDuo(false)
+    }
   }
 
   hasConditionalField(fieldName) {


### PR DESCRIPTION
Au niveau de la base de données, il est actuellement possible de créer une offre duo qui n'est pas un événement.
Ici on fait en sorte que ce ne soit pas possible depuis l'interface pro. Sur le formulaire de création d'une offre, il était possible de sélectionner un type "événement", cocher la case "duo" puis changer le type pour un "livre" par exemple, et l'offre créée était quand même considérée comme duo.