### PR TITLE
(PC-4815): pages.Offers: remove unused types and loadTypes()

### DIFF
--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -82,9 +82,8 @@ class Offers extends PureComponent {
   }
 
   getPaginatedOffersWithFilters = ({ shouldTriggerSpinner }) => {
-    const { loadTypes, types, saveSearchFilters } = this.props
+    const { saveSearchFilters } = this.props
     const { nameSearchValue, selectedVenueId, page } = this.state
-    types.length === 0 && loadTypes()
     saveSearchFilters({ name: nameSearchValue, venueId: selectedVenueId, page })
 
     shouldTriggerSpinner && this.setState({ isLoading: true })
@@ -297,7 +296,6 @@ Offers.propTypes = {
   handleOnActivateAllVenueOffersClick: PropTypes.func.isRequired,
   handleOnDeactivateAllVenueOffersClick: PropTypes.func.isRequired,
   loadOffers: PropTypes.func.isRequired,
-  loadTypes: PropTypes.func.isRequired,
   offers: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   query: PropTypes.shape({
     change: PropTypes.func.isRequired,

--- a/src/components/pages/Offers/OffersContainer.js
+++ b/src/components/pages/Offers/OffersContainer.js
@@ -15,7 +15,6 @@ export const mapStateToProps = state => {
     lastTrackerMoment: lastTrackerMoment(state, 'offers'),
     notification: state.notification,
     offers: selectOffers(state),
-    types: state.data.types,
     searchFilters: state.offers.searchFilters,
   }
 }
@@ -93,10 +92,8 @@ export const mapDispatchToProps = dispatch => {
           })
 
           return { page, pageCount, offersCount }
-        },
+        }
       ),
-
-    loadTypes: () => dispatch(requestData({ apiPath: '/types' })),
   }
 }
 

--- a/src/components/pages/Offers/__specs__/Offers.spec.jsx
+++ b/src/components/pages/Offers/__specs__/Offers.spec.jsx
@@ -84,7 +84,6 @@ describe('src | components | pages | Offers | Offers', () => {
       handleOnActivateAllVenueOffersClick: jest.fn(),
       handleOnDeactivateAllVenueOffersClick: jest.fn(),
       loadOffers: jest.fn().mockResolvedValue({ page: 1, pageCount: 2, offersCount: 5 }),
-      loadTypes: jest.fn(),
       saveSearchFilters: jest.fn(),
       offers: [
         {
@@ -96,7 +95,6 @@ describe('src | components | pages | Offers | Offers', () => {
         change,
         parse,
       },
-      types: [],
       venue: { name: 'Ma Venue', id: 'JI' },
     }
     fetchAllVenuesByProUser.mockResolvedValue(proVenues)


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-4815

Cette props n’était pas utilisée dans la section Offers:
```
$ git grep types | grep -v prop-type
Offers.jsx:    const { loadTypes, types, saveSearchFilters } = this.props
Offers.jsx:    types.length === 0 && loadTypes()
OffersContainer.js:    types: state.data.types,
OffersContainer.js:    loadTypes: () => dispatch(requestData({ apiPath: '/types' })),
__specs__/Offers.spec.jsx:      types: [],
```