### PR TITLE
MediationsManager: Fix typo (missing space between two words)

### DIFF
--- a/src/components/pages/Offer/MediationsManager/MediationsManager.jsx
+++ b/src/components/pages/Offer/MediationsManager/MediationsManager.jsx
@@ -39,8 +39,7 @@ class MediationsManager extends PureComponent {
               <b>
                 {'spécificité du pass Culture'}
               </b>
-              {'. Prenez le'}
-              {'temps de les choisir avec soin !'}
+              {'. Prenez le temps de les choisir avec soin !'}
             </p>
           </div>
           <ul className="mediations-list">


### PR DESCRIPTION
Pourquoi découper la phrase en 2 ? Ne peut-on pas écrire simplement ::

    {'. Prenez le temps de les choisir avec soin !'}

(Je ne connais pas grand chose à React et JSX, n'hésitez pas à pointer l'évidence...)