### PR TITLE
Rlecellier/another fix 4284

### DIFF
--- a/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
+++ b/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
@@ -58,7 +58,7 @@ const ActionsBar = props => {
 
       <div className="actions-container">
         <button
-          className="primary-button"
+          className="primary-button with-icon"
           onClick={handleDeactivate}
           type="button"
         >
@@ -66,7 +66,7 @@ const ActionsBar = props => {
           {'Désactiver'}
         </button>
         <button
-          className="primary-button"
+          className="primary-button with-icon"
           onClick={handleActivate}
           type="button"
         >

--- a/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
+++ b/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
@@ -24,6 +24,7 @@ const ActionsBar = props => {
     await fetchFromApiWithCredentials('/offers/active-status', 'PATCH', body)
     refreshOffers({ shouldTriggerSpinner: false })
     trackActivateOffers(selectedOfferIds)
+    handleClose()
   }
   async function handleDeactivate() {
     const body = {
@@ -33,6 +34,7 @@ const ActionsBar = props => {
     await fetchFromApiWithCredentials('/offers/active-status', 'PATCH', body)
     refreshOffers({ shouldTriggerSpinner: false })
     trackDeactivateOffers(selectedOfferIds)
+    handleClose()
   }
   function handleClose() {
     setSelectedOfferIds([])

--- a/src/components/pages/Offers/ActionsBar/__specs__/ActionsBar.spec.jsx
+++ b/src/components/pages/Offers/ActionsBar/__specs__/ActionsBar.spec.jsx
@@ -10,7 +10,7 @@ const renderActionsBar = props => {
   return render(<ActionsBar {...props} />)
 }
 
-jest.spyOn(fetchUtils, 'fetchFromApiWithCredentials')
+jest.spyOn(fetchUtils, 'fetchFromApiWithCredentials').mockImplementation(() => Promise.resolve())
 
 describe('src | components | pages | Offers | ActionsBar', () => {
   let props
@@ -25,7 +25,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
     }
   })
 
-  it('should activate selected offers on click on "Activer" button', () => {
+  it('should activate selected offers on click on "Activer" button', async () => {
     // given
     renderActionsBar(props)
     const activateButton = screen.queryByText('Activer')
@@ -41,7 +41,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
     fireEvent.click(activateButton)
 
     // then
-    waitFor(() => {
+    await waitFor(() => {
       expect(fetchUtils.fetchFromApiWithCredentials).toHaveBeenLastCalledWith(
         '/offers/active-status',
         'PATCH',
@@ -54,7 +54,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
     })
   })
 
-  it('should deactivate selected offers on click on "Désactiver" button', () => {
+  it('should deactivate selected offers on click on "Désactiver" button', async () => {
     // given
     renderActionsBar(props)
     const activateButton = screen.queryByText('Désactiver')
@@ -70,7 +70,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
     fireEvent.click(activateButton)
 
     // then
-    waitFor(() => {
+    await waitFor(() => {
       expect(fetchUtils.fetchFromApiWithCredentials).toHaveBeenLastCalledWith(
         '/offers/active-status',
         'PATCH',

--- a/src/styles/components/layout/buttons/PrimaryButton/_PrimaryButton.scss
+++ b/src/styles/components/layout/buttons/PrimaryButton/_PrimaryButton.scss
@@ -1,9 +1,6 @@
 @mixin primary {
   @include button();
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
   background-color: $primary;
   border: 3px solid $primary;
   border-radius: rem(24px);
@@ -12,11 +9,6 @@
   height: rem(40px);
   line-height: rem(34px);
   padding: 0 rem(16px);
-
-  img {
-    height: rem(24px);
-    margin-right: rem(4px);
-  }
 
   svg {
     height: rem(25px);
@@ -46,6 +38,17 @@
     border: 3px solid $primary-disabled;
     cursor: not-allowed;
     opacity: 1;
+  }
+
+  &.with-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      height: rem(24px);
+      margin-right: rem(4px);
+    }
   }
 }
 

--- a/src/styles/components/layout/buttons/PrimaryButton/_PrimaryButton.scss
+++ b/src/styles/components/layout/buttons/PrimaryButton/_PrimaryButton.scss
@@ -14,7 +14,7 @@
   padding: 0 rem(16px);
 
   img {
-    height: rem(25px);
+    height: rem(24px);
     margin-right: rem(4px);
   }
 

--- a/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
+++ b/src/styles/components/pages/Offers/OfferItem/_OfferItem.scss
@@ -121,6 +121,10 @@
     width: rem(135px);
   }
 
+  .stock-column {
+    width: rem(100px);
+  }
+
   .status-column {
     width: rem(145px);
   }

--- a/src/styles/components/pages/Offers/_Offers.scss
+++ b/src/styles/components/pages/Offers/_Offers.scss
@@ -29,6 +29,7 @@
   }
 
   .offers-list-actions {
+    display: flex;
     border-bottom: 1px solid $grey-dark;
     font-size: 0.8rem;
     margin-bottom: rem(16px);
@@ -42,7 +43,6 @@
 
     button:first-child {
       border-right: 1px solid $grey-dark;
-      padding-right: rem(8px);
     }
   }
 
@@ -59,7 +59,7 @@
       border-bottom: 1px solid $grey-medium;
 
       td {
-        padding: rem(16px) rem(8px);
+        padding: rem(16px) rem(10px);
         vertical-align: middle;
       }
 

--- a/src/styles/global/_buttons.scss
+++ b/src/styles/global/_buttons.scss
@@ -1,7 +1,4 @@
 .button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
   font-weight: $weight-bold;
   font-size: $font-size;
   line-height: $body-line-height;


### PR DESCRIPTION
Fix des test de la bar d'action et aussi quelques retour design: 

Le “illimité” et le statut sont très collés. Est ce qu’on peut augmenter l’espace : soit en réduisant légèrement la marge entre le statut et le bouton “activer”, soit en réduisant légèrement la colonne de titre? On peut voir ça en live ensemble   
-> les cellules passent de 8 à 10px de padding

Les icones me paraissent trop grosses sur les boutons “désactiver” et “activer” dans la barre - d’action
-> ajustement de 25px à 24px (comme sur la maquette)

Au niveau du comportement, je pense qu’il y a quelque chose qu’on peut ajuster : au clique sur” désactiver” par exemple, la barre d’action devrait se refermer toute seule, puisque l’utilisateur a a priori terminé son action et que la snackbar s’affichera (PC-4675: Refonte Offres - Afficher un message de succès après la désactivation / activation des offres EN COURS  Lina Yahi tu veux qu’on mette ça dans un autre ticket ?   
-> le handleClose avait sauté sur la dernier version de la PR, je l'ai remis.
