### PR TITLE
(PC-4892): use redux-thunk to retrieve offer

### DIFF
--- a/src/components/pages/Mediation/Mediation.jsx
+++ b/src/components/pages/Mediation/Mediation.jsx
@@ -42,7 +42,7 @@ class Mediation extends PureComponent {
   onHandleDataRequest = (handleSuccess, handleFail) => {
     const {
       getMediation,
-      getOffer,
+      loadOffer,
       match: {
         params: { mediationId, offerId },
       },
@@ -50,7 +50,7 @@ class Mediation extends PureComponent {
     } = this.props
     const { isNew } = this.state
     if (!offer) {
-      getOffer(offerId)
+      loadOffer(offerId)
     }
     if (!isNew) {
       getMediation(mediationId, handleSuccess, handleFail)
@@ -455,8 +455,8 @@ Mediation.defaultProps = {
 Mediation.propTypes = {
   createOrUpdateMediation: PropTypes.func.isRequired,
   getMediation: PropTypes.func.isRequired,
-  getOffer: PropTypes.func.isRequired,
   history: PropTypes.shape().isRequired,
+  loadOffer: PropTypes.func.isRequired,
   match: PropTypes.shape().isRequired,
   mediation: PropTypes.shape(),
   offer: PropTypes.shape().isRequired,

--- a/src/components/pages/Mediation/MediationContainer.js
+++ b/src/components/pages/Mediation/MediationContainer.js
@@ -5,11 +5,12 @@ import { requestData } from 'redux-saga-data'
 
 import { withRequiredLogin } from 'components/hocs'
 import { selectOfferById } from 'store/offers/selectors'
+import { loadOffer } from 'store/offers/thunks'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectMediationById } from 'store/selectors/data/mediationsSelectors'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
 import { selectVenueById } from 'store/selectors/data/venuesSelectors'
-import { mediationNormalizer, offerNormalizer } from 'utils/normalizers'
+import { mediationNormalizer } from 'utils/normalizers'
 
 import Mediation from './Mediation'
 
@@ -30,14 +31,6 @@ export const mapStateToProps = (state, ownProps) => {
 
 export const mapDispatchToProps = dispatch => {
   return {
-    getOffer: offerId => {
-      dispatch(
-        requestData({
-          apiPath: `/offers/${offerId}`,
-          normalizer: offerNormalizer,
-        })
-      )
-    },
     getMediation: (mediationId, handleSuccess, handleFail) => {
       dispatch(
         requestData({
@@ -48,6 +41,7 @@ export const mapDispatchToProps = dispatch => {
         })
       )
     },
+    loadOffer: offerId => dispatch(loadOffer(offerId)),
     showOfferModificationErrorNotification: error => {
       dispatch(
         showNotificationV1({

--- a/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
+++ b/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
@@ -1,3 +1,5 @@
+import * as offersThunks from 'store/offers/thunks'
+
 import { mapDispatchToProps } from '../MediationContainer'
 import { mapStateToProps } from '../MediationContainer'
 
@@ -17,7 +19,7 @@ describe('src | components | pages | MediationContainer', () => {
 
       // then
       expect(result).toStrictEqual({
-        getOffer: expect.any(Function),
+        loadOffer: expect.any(Function),
         getMediation: expect.any(Function),
         showOfferModificationErrorNotification: expect.any(Function),
         showOfferModificationValidationNotification: expect.any(Function),
@@ -26,39 +28,18 @@ describe('src | components | pages | MediationContainer', () => {
     })
   })
 
-  describe('getOffer', () => {
+  describe('loadOffer', () => {
     it('should retrieve offer with offerId', () => {
       // given
-      const { getOffer } = mapDispatchToProps(dispatch, props)
+      jest.spyOn(offersThunks, 'loadOffer')
+      const { loadOffer } = mapDispatchToProps(dispatch, props)
       const offerId = 'offerId'
 
       // when
-      getOffer(offerId)
+      loadOffer(offerId)
 
       // then
-      expect(dispatch).toHaveBeenCalledWith({
-        config: {
-          apiPath: '/offers/offerId',
-          method: 'GET',
-          normalizer: {
-            mediations: 'mediations',
-            product: {
-              normalizer: {
-                offers: 'offers',
-              },
-              stateKey: 'products',
-            },
-            stocks: 'stocks',
-            venue: {
-              normalizer: {
-                managingOfferer: 'offerers',
-              },
-              stateKey: 'venues',
-            },
-          },
-        },
-        type: 'REQUEST_DATA_GET_/OFFERS/OFFERID',
-      })
+      expect(offersThunks.loadOffer).toHaveBeenCalledWith(offerId)
     })
   })
 

--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -24,7 +24,6 @@ import { CGU_URL } from 'utils/config'
 import { translateApiParamsToQueryParams } from 'utils/translate'
 
 import { musicOptions, showOptions } from '../../../../utils/edd'
-import { offerNormalizer } from '../../../../utils/normalizers'
 import { pluralize } from '../../../../utils/pluralize'
 import { isAllocineOffer, isOfferFromStockProvider } from '../domain/localProvider'
 import offerIsRefundable from '../domain/offerIsRefundable'
@@ -32,7 +31,6 @@ import LocalProviderInformation from '../LocalProviderInformation/LocalProviderI
 import MediationsManager from '../MediationsManager/MediationsManagerContainer'
 import StocksManagerContainer from '../StocksManager/StocksManagerContainer'
 import { getDurationInHours, getDurationInMinutes } from '../utils/duration'
-
 
 const DURATION_LIMIT_TIME = 100
 
@@ -122,6 +120,7 @@ class OfferCreation extends PureComponent {
     const {
       dispatch,
       history,
+      loadOffer,
       match: {
         params: { offerId },
       },
@@ -134,12 +133,7 @@ class OfferCreation extends PureComponent {
     const { offererId, venueId } = query.translate()
 
     if (offerId !== 'creation') {
-      dispatch(
-        requestData({
-          apiPath: `/offers/${offerId}`,
-          normalizer: offerNormalizer,
-        })
-      )
+      loadOffer(offerId)
     } else if (venueId) {
       dispatch(
         requestData({
@@ -828,6 +822,7 @@ OfferCreation.propTypes = {
   currentUser: PropTypes.shape().isRequired,
   dispatch: PropTypes.func.isRequired,
   isEditableOffer: PropTypes.bool.isRequired,
+  loadOffer: PropTypes.func.isRequired,
   location: PropTypes.shape().isRequired,
   query: PropTypes.shape().isRequired,
   selectedOfferType: PropTypes.shape().isRequired,

--- a/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
+++ b/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
@@ -6,6 +6,7 @@ import { compose } from 'redux'
 import { withRequiredLogin } from 'components/hocs'
 import withTracking from 'components/hocs/withTracking'
 import { selectOfferById } from 'store/offers/selectors'
+import { loadOffer } from 'store/offers/thunks'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
 import { selectOfferers } from 'store/selectors/data/offerersSelectors'
@@ -108,6 +109,7 @@ export const mapStateToProps = (state, ownProps) => {
 }
 
 export const mapDispatchToProps = dispatch => ({
+  loadOffer: offerId => dispatch(loadOffer(offerId)),
   showValidationNotification: () => {
     dispatch(
       showNotificationV1({

--- a/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
+++ b/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
@@ -109,6 +109,7 @@ describe('src | OfferCreation', () => {
         lastProvider: null,
       },
       history: {},
+      loadOffer: jest.fn(),
       offersSearchFilters: {},
       offerers: [],
       offerer: {

--- a/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
+++ b/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
@@ -22,7 +22,6 @@ import Titles from 'components/layout/Titles/Titles'
 import { OFFERERS_API_PATH } from 'config/apiPaths'
 import { CGU_URL } from 'utils/config'
 import { musicOptions, showOptions } from 'utils/edd'
-import { offerNormalizer } from 'utils/normalizers'
 import { pluralize } from 'utils/pluralize'
 
 import { isAllocineOffer, isOfferFromStockProvider } from '../domain/localProvider'
@@ -118,6 +117,7 @@ class OfferEdition extends PureComponent {
     const {
       dispatch,
       history,
+      loadOffer,
       match: {
         params: { offerId },
       },
@@ -130,12 +130,7 @@ class OfferEdition extends PureComponent {
     const { offererId, venueId } = query.translate()
 
     if (offerId !== 'creation') {
-      dispatch(
-        requestData({
-          apiPath: `/offers/${offerId}`,
-          normalizer: offerNormalizer,
-        })
-      )
+      loadOffer(offerId)
     } else if (venueId) {
       dispatch(
         requestData({
@@ -733,6 +728,7 @@ OfferEdition.defaultProps = {
 OfferEdition.propTypes = {
   currentUser: PropTypes.shape().isRequired,
   dispatch: PropTypes.func.isRequired,
+  loadOffer: PropTypes.func.isRequired,
   location: PropTypes.shape().isRequired,
   query: PropTypes.shape().isRequired,
   selectedOfferType: PropTypes.shape().isRequired,

--- a/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
+++ b/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
@@ -6,6 +6,7 @@ import { compose } from 'redux'
 import { withRequiredLogin } from 'components/hocs'
 import withTracking from 'components/hocs/withTracking'
 import { selectOfferById } from 'store/offers/selectors'
+import { loadOffer } from 'store/offers/thunks'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectOffererById, selectOfferers } from 'store/selectors/data/offerersSelectors'
 import { selectProductById } from 'store/selectors/data/productsSelectors'
@@ -114,6 +115,7 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => {
 }
 
 export const mapDispatchToProps = dispatch => ({
+  loadOffer: offerId => dispatch(loadOffer(offerId)),
   updateFormSetIsDuo: isDuo => {
     dispatch(
       mergeForm('offer', {

--- a/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
@@ -30,6 +30,7 @@ describe('components | OfferEdition', () => {
         isDuo: false,
       },
       isEditableOffer: true,
+      loadOffer: jest.fn(),
       loadVenue: jest.fn(),
       location: {
         search: '?lieu=AQ',

--- a/src/repository/pcapi/pcapi.js
+++ b/src/repository/pcapi/pcapi.js
@@ -6,6 +6,10 @@ import {
 } from 'components/pages/Offers/_constants'
 import { client } from 'repository/pcapi/pcapiClient'
 
+export const loadOffer = async offerId => {
+  return client.get(`/offers/${offerId}`)
+}
+
 export const loadFilteredOffers = async ({
   nameSearchValue = ALL_OFFERS,
   offererId = ALL_OFFERERS,

--- a/src/store/offers/thunks.js
+++ b/src/store/offers/thunks.js
@@ -1,11 +1,24 @@
-import { loadFilteredOffers } from 'repository/pcapi/pcapi'
+import * as pcapi from 'repository/pcapi/pcapi'
 import { setStocks, setVenues } from 'store/reducers/data'
+
 import { setOffers } from './actions'
+
+export const loadOffer = offerId => {
+  return dispatch => {
+    return pcapi.loadOffer(offerId).then(rawOffer => {
+      const { stocks, venue, ...offer } = rawOffer
+      dispatch(setOffers([offer]))
+      dispatch(setStocks(stocks))
+      dispatch(setVenues([venue]))
+    })
+  }
+}
 
 export const loadOffers = filters => {
   return dispatch => {
-    return loadFilteredOffers(filters).then(
-      ({ offers: offersRecap, page, page_count: pageCount, total_count: offersCount }) => {
+    return pcapi
+      .loadFilteredOffers(filters)
+      .then(({ offers: offersRecap, page, page_count: pageCount, total_count: offersCount }) => {
         const { offers, stocks, venues } = offersRecapNormalizer(offersRecap)
 
         dispatch(setOffers(offers))
@@ -13,8 +26,7 @@ export const loadOffers = filters => {
         dispatch(setVenues(venues))
 
         return { page, pageCount, offersCount }
-      }
-    )
+      })
   }
 }
 


### PR DESCRIPTION
Les page d'edition et de creation d'offre allaient chercher leurs données dans `state.offers.list` et remplissaient `state.data.offers`.
Ici on utilisera `state.offers.list` pour stocker et récupérer les données.