### PR TITLE
(PC-4892): quick fix in order to have a refreshed offer after edition

### DIFF
--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -56,15 +56,14 @@ const CONDITIONAL_FIELDS = {
 }
 
 class OfferCreation extends PureComponent {
-  constructor(props) {
-    super(props)
-    const { dispatch } = this.props
-    dispatch(resetForm())
-  }
-
   componentDidMount() {
+    const { dispatch } = this.props
     this.handleShowStocksManager()
     this.setDefaultBookingEmailIfNew()
+
+    // pass-culture-shared have a dedicated redux state for forms.
+    // it's not correctly reset when we came back from offer edition.
+    dispatch(resetForm())
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
j'ai du mal à saisir le fonctionnement global de ce module de formulaire dans shared.
Le fait est qu'apres l'édition state.forms.offer n'est pas à jours, en faisant un reset ici, on force l'utilisation des valeurs initial.

Second commit pour fixer l'activation et la désactivation.