### PR TITLE
Standard : enable usage of props WITHOUT destructuring

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,6 +57,7 @@
       }
     ],
     "react/no-set-state": "off",
+    "react/destructuring-assignment": "off",
     "react/prop-types": "off",
     "react/require-optimization": "off",
     "react/static-property-placement": "off",

--- a/src/components/layout/form/fields/TextField.jsx
+++ b/src/components/layout/form/fields/TextField.jsx
@@ -1,4 +1,3 @@
-/* eslint react/destructuring-assignment: 0 */
 /* eslint react/function-component-definition: 0 */
 import classnames from 'classnames'
 import PropTypes from 'prop-types'


### PR DESCRIPTION
Link to Notion standard action ticket : https://www.notion.so/D-sactiver-la-r-gle-ESLint-forcant-le-destructuring-des-props-4602256fb4964fc4ba5121948841264b

Note : usage of props WITH destructuring is still enabled.