### PR TITLE
[PC-5155] Option duo qui se coche automatiquement lors de la création d'offre

### DIFF
--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -650,8 +650,9 @@ class OfferCreation extends PureComponent {
                 {isEventType && (
                   <div className="select-duo-offer">
                     <input
-                      className="offer-duo-checkbox input"
                       checked={formInitialValues.isDuo}
+                      className="offer-duo-checkbox input"
+                      defaultChecked
                       disabled={readOnly ? 'disabled' : ''}
                       id="isDuo"
                       onChange={this.handleCheckIsDuo}

--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -651,10 +651,10 @@ class OfferCreation extends PureComponent {
                   <div className="select-duo-offer">
                     <input
                       className="offer-duo-checkbox input"
-                      defaultChecked={formInitialValues.isDuo}
+                      checked={formInitialValues.isDuo}
                       disabled={readOnly ? 'disabled' : ''}
                       id="isDuo"
-                      onClick={this.handleCheckIsDuo}
+                      onChange={this.handleCheckIsDuo}
                       type="checkbox"
                     />
                     <label htmlFor="isDuo">

--- a/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
+++ b/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
@@ -917,7 +917,7 @@ describe('src | OfferCreation', () => {
         const isDuoCheckbox = wrapper.find('.offer-duo-checkbox')
 
         // then
-        expect(isDuoCheckbox.prop('defaultChecked')).toBe(true)
+        expect(isDuoCheckbox.prop('checked')).toBe(true)
       })
 
       it('should display unchecked isDuo checkbox when offer is not duo', () => {
@@ -929,7 +929,7 @@ describe('src | OfferCreation', () => {
         const isDuoCheckbox = wrapper.find('.offer-duo-checkbox')
 
         // then
-        expect(isDuoCheckbox.prop('defaultChecked')).toBe(false)
+        expect(isDuoCheckbox.prop('checked')).toBe(false)
       })
     })
   })

--- a/testcafe/06_offers.js
+++ b/testcafe/06_offers.js
@@ -15,6 +15,7 @@ const venueOption = Selector('#offer-venueId option')
 const typeOption = Selector('#offer-type option')
 const durationMinutesInput = Selector('input.field-duration')
 const descriptionInput = Selector('#offer-description')
+const isDuo = Selector('#isDuo')
 const submitButton = Selector('button').withText('Enregistrer')
 
 fixture('En étant sur la page des offres,')
@@ -118,4 +119,39 @@ test('je peux créer une offre avec des sous-types', async t => {
     .ok()
     .expect(musicSubTypeOption.withText(eventMusicSubType).selected)
     .ok()
+})
+
+
+
+test('une offre Event est duo par défaut', async t => {
+  const { user } = await fetchSandbox(
+    'pro_07_offer',
+    'get_existing_pro_validated_user_with_validated_offerer_validated_user_offerer_with_physical_venue'
+  )
+  const buttonClose = Selector('#close-manager')
+  const buttonModifyOffer = Selector('#modify-offer-button')
+  await navigateToNewOfferAs(user)(t)
+
+  await t
+    .typeText(nameInput, 'Offre Duo')
+    .click(typeInput)
+    .click(typeOption.withText('Spectacle vivant')) // choose an event
+    // .click(isDuo) // TODO: remove. We shouldn't need this. 
+    .expect(isDuo.checked)
+    .ok() // First fail: isDuo should be checked by default for events
+    .click(isDuo)
+    .expect(isDuo.checked) // Make sure we can uncheck
+    .notOk()
+    .click(isDuo)
+    .click(submitButton)
+    .click(buttonClose)
+    .expect(isDuo.checked)
+    .ok()
+    .click(buttonModifyOffer)
+    .expect(isDuo.checked)
+    .ok()
+    .click(isDuo) // Uncheck isDuo
+    .click(submitButton)
+    .expect(isDuo.checked)
+    .notOk() // Second fail: TODO: this should be true
 })

--- a/testcafe/06_offers.js
+++ b/testcafe/06_offers.js
@@ -136,7 +136,7 @@ test('une offre Event est duo par défaut', async t => {
     .typeText(nameInput, 'Offre Duo')
     .click(typeInput)
     .click(typeOption.withText('Spectacle vivant')) // choose an event
-    // .click(isDuo) // TODO: remove. We shouldn't need this. 
+    .click(isDuo) // TODO: remove. We shouldn't need this. 
     .expect(isDuo.checked)
     .ok() // First fail: isDuo should be checked by default for events
     .click(isDuo)
@@ -153,5 +153,5 @@ test('une offre Event est duo par défaut', async t => {
     .click(isDuo) // Uncheck isDuo
     .click(submitButton)
     .expect(isDuo.checked)
-    .notOk() // Second fail: TODO: this should be true
+    .notOk()
 })

--- a/testcafe/06_offers.js
+++ b/testcafe/06_offers.js
@@ -136,9 +136,8 @@ test('une offre Event est duo par défaut', async t => {
     .typeText(nameInput, 'Offre Duo')
     .click(typeInput)
     .click(typeOption.withText('Spectacle vivant')) // choose an event
-    .click(isDuo) // TODO: remove. We shouldn't need this. 
     .expect(isDuo.checked)
-    .ok() // First fail: isDuo should be checked by default for events
+    .ok()
     .click(isDuo)
     .expect(isDuo.checked) // Make sure we can uncheck
     .notOk()


### PR DESCRIPTION
**Problem**: The form was correctly submitted and the new offer was passed as props to OfferCreation as expected.
However, the field 'isDuo' was not controlled. As a result, the checkbox didn't refresh properly.
the property defaultChecked is used on initial render.
If you reloaded the page though, it would show the correct value.

**Fix**: use the property 'checked' which is controlled

**Reference**: https://reactjs.org/docs/forms.html#default-value