### PR TITLE
(PC-4888) : Offer action bar design: button spacing

### DIFF
--- a/src/styles/components/pages/Offers/_ActionsBar.scss
+++ b/src/styles/components/pages/Offers/_ActionsBar.scss
@@ -10,7 +10,9 @@
 
   .actions-container {
     display: flex;
-    flex: auto;
-    justify-content: space-around;
+    margin: auto;
+    button {
+      margin-left: 40px;
+    }
   }
 }


### PR DESCRIPTION
Changement de l'espacement des boutons sur la bar d'actions de la liste des offres:

![actions_bar_button_spacing_2](https://user-images.githubusercontent.com/139848/98548704-1ce4d980-229a-11eb-8ee7-d7344207b4e0.png)
