### PR TITLE
(PC-5019) Edit wording of stock or date cancellation warning

### DIFF
--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/DeleteDialog.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/DeleteDialog.jsx
@@ -10,7 +10,9 @@ const DeleteDialog = ({ isEvent, onCancelDeleteClick, onConfirmDeleteClick }) =>
       {isEvent ? 'cette date' : 'ce stock'}
       {', '}
       {'vous supprimerez aussi toutes les réservations associées. '}
-      {isEvent && <br />}
+      <br />
+      {"L'ensemble des utilisateurs seront automatiquement avertis par mail. "}
+      <br />
       {'Êtes-vous sûr de vouloir continuer ?'}
     </td>
 

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/DeleteDialog.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/DeleteDialog.spec.jsx
@@ -15,7 +15,9 @@ describe('src | components | pages | Offer | StockItem | DeleteDialog', () => {
 
     // then
     const td = wrapper.find('td')
-    expect(td.at(0).text()).toBe('En confirmant l’annulation de cette date, vous supprimerez aussi toutes les réservations associées. Êtes-vous sûr de vouloir continuer ?')
+    expect(td.at(0).text()).toBe(
+      "En confirmant l’annulation de cette date, vous supprimerez aussi toutes les réservations associées. L'ensemble des utilisateurs seront automatiquement avertis par mail. Êtes-vous sûr de vouloir continuer ?"
+    )
     expect(td.at(1).find('button').find({ children: 'Oui' })).toHaveLength(1)
     expect(td.at(2).find('button').find({ children: 'Non' })).toHaveLength(1)
   })
@@ -31,7 +33,9 @@ describe('src | components | pages | Offer | StockItem | DeleteDialog', () => {
 
     // then
     const td = wrapper.find('td')
-    expect(td.at(0).text()).toBe('En confirmant l’annulation de ce stock, vous supprimerez aussi toutes les réservations associées. Êtes-vous sûr de vouloir continuer ?')
+    expect(td.at(0).text()).toBe(
+      "En confirmant l’annulation de ce stock, vous supprimerez aussi toutes les réservations associées. L'ensemble des utilisateurs seront automatiquement avertis par mail. Êtes-vous sûr de vouloir continuer ?"
+    )
     expect(td.at(1).find('button').find({ children: 'Oui' })).toHaveLength(1)
     expect(td.at(2).find('button').find({ children: 'Non' })).toHaveLength(1)
   })


### PR DESCRIPTION
Cette modification ajoute des précisions à l'acteur culturel lors de l'annulation d'un stock ou d'une date d'évènement quant à l'annulation des réservations liées.