### PR TITLE
(PC-4888) : Offers.ActionsBar: center button on page.

### DIFF
--- a/src/styles/components/pages/Offers/_ActionsBar.scss
+++ b/src/styles/components/pages/Offers/_ActionsBar.scss
@@ -5,7 +5,7 @@
 
   .nb-offers-description {
     display: inline-block;
-    min-width: rem(160px);
+    position: absolute;
   }
 
   .actions-container {


### PR DESCRIPTION
Les bouton doivent etre centré sur la page et non sur la place restante dans la barre d'action.