### PR TITLE
(PC-5007) : Add checkboxes to style guide

### DIFF
--- a/src/components/layout/form/fields/CheckboxField.jsx
+++ b/src/components/layout/form/fields/CheckboxField.jsx
@@ -4,21 +4,18 @@ import { Field } from 'react-final-form'
 
 class CheckboxField extends PureComponent {
   renderField = ({ input }) => {
-    const {
-      checked,
-      id,
-      label,
-    } = this.props
+    const { checked, id, label } = this.props
 
     return (
       <div>
         <input
           {...input}
+          className="input-checkbox"
           defaultChecked={checked}
           id={id}
           type="checkbox"
         />
-        { label && (
+        {label && (
           <label htmlFor={id}>
             {label}
           </label>

--- a/src/components/layout/inputs/CheckboxInput/CheckboxInput.jsx
+++ b/src/components/layout/inputs/CheckboxInput/CheckboxInput.jsx
@@ -1,0 +1,55 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export const CheckboxInput = ({
+  onChange,
+  name,
+  label,
+  checked,
+  labelAttributes,
+  className,
+  hiddenLabel,
+  ...attributes
+}) => {
+  let inputClasses = className ? className.split(' ') : []
+  inputClasses.push('input-checkbox')
+  let textClasses = ['input-checkbox-label']
+  if (hiddenLabel) {
+    textClasses.push('label-hidden')
+  }
+
+  return (
+    <label
+      className="field field-checkbox"
+      {...labelAttributes}
+    >
+      <input
+        checked={checked}
+        className={inputClasses.join(' ')}
+        name={name}
+        onChange={onChange}
+        type="checkbox"
+        {...attributes}
+      />
+      <span className={textClasses.join(' ')}>
+        {label}
+      </span>
+    </label>
+  )
+}
+
+CheckboxInput.defaultProps = {
+  className: '',
+  hiddenLabel: false,
+  labelAttributes: {},
+}
+
+CheckboxInput.propTypes = {
+  checked: PropTypes.bool.isRequired,
+  className: PropTypes.string,
+  hiddenLabel: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  labelAttributes: PropTypes.shape(),
+  name: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+}

--- a/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 
 import Icon from 'components/layout/Icon'
+import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 
 import { getBookingStatusDisplayInformations } from '../CellsFormatter/utils/bookingStatusConverter'
 
@@ -139,17 +140,15 @@ class FilterByBookingStatus extends Component {
               </div>
               {bookingStatuses.map(bookingStatus => (
                 <Fragment key={bookingStatus.value}>
-                  <label data-status-filter-tooltip>
-                    <input
-                      checked={!bookingStatusFilters.includes(bookingStatus.value)}
-                      data-status-filter-tooltip
-                      id={`bs-${bookingStatus.value}`}
-                      name={bookingStatus.value}
-                      onChange={this.handleCheckboxChange}
-                      type="checkbox"
-                    />
-                    {bookingStatus.title}
-                  </label>
+                  <CheckboxInput
+                    checked={!bookingStatusFilters.includes(bookingStatus.value)}
+                    data-status-filter-tooltip
+                    id={`bs-${bookingStatus.value}`}
+                    label={bookingStatus.title}
+                    labelAttributes={{ 'data-status-filter-tooltip': true }}
+                    name={bookingStatus.value}
+                    onChange={this.handleCheckboxChange}
+                  />
                 </Fragment>
               ))}
             </div>

--- a/src/components/pages/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.jsx
@@ -106,6 +106,7 @@ describe('components | FilterByBookingStatus', () => {
       expect(checkbox).toHaveLength(2)
       expect(checkbox.at(0).props()).toStrictEqual({
         checked: true,
+        className: 'input-checkbox',
         'data-status-filter-tooltip': true,
         id: 'bs-booked',
         name: 'booked',
@@ -114,6 +115,7 @@ describe('components | FilterByBookingStatus', () => {
       })
       expect(checkbox.at(1).props()).toStrictEqual({
         checked: true,
+        className: 'input-checkbox',
         'data-status-filter-tooltip': true,
         id: 'bs-validated',
         name: 'validated',

--- a/src/components/pages/Offers/OfferItem/OfferItem.jsx
+++ b/src/components/pages/Offers/OfferItem/OfferItem.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import Icon from 'components/layout/Icon'
+import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 import Thumb from 'components/layout/Thumb'
 import { isOfferFullyBooked } from 'components/pages/Offers/domain/isOfferFullyBooked'
 import { computeVenueDisplayName } from 'repository/venuesService'
@@ -60,14 +61,15 @@ const OfferItem = ({ disabled, offer, stocks, venue, isSelected, selectOffer }) 
   return (
     <tr className={`offer-item ${isOfferInactiveOrExpired ? 'inactive' : ''} offer-row`}>
       <td className="select-column">
-        <input
+        <CheckboxInput
           checked={isSelected}
           className="select-offer-checkbox"
           data-testid={`select-offer-${offer.id}`}
           disabled={disabled}
+          hiddenLabel
           id={`select-offer-${offer.id}`}
+          label={`Selectionner l'offre ${offer.name}`}
           onChange={handleOnChangeSelected}
-          type="checkbox"
         />
       </td>
       <td className="thumb-column">

--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -4,6 +4,7 @@ import React, { Fragment, PureComponent } from 'react'
 import { Link } from 'react-router-dom'
 
 import Icon from 'components/layout/Icon'
+import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 import Select from 'components/layout/inputs/Select'
 import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import Main from 'components/layout/Main'
@@ -442,13 +443,14 @@ class Offers extends PureComponent {
       <thead>
         <tr>
           <th className="th-checkbox">
-            <input
+            <CheckboxInput
               checked={areAllOffersSelected}
-              className="select-offer-checkbox"
+              className="input-checkbox select-offer-checkbox"
               disabled={this.isAdminForbidden(savedSearchFilters) || !offers.length}
+              hiddenLabel
               id="select-offer-checkbox"
+              label="Selectionner toutes les offres"
               onChange={this.selectAllOffers}
-              type="checkbox"
             />
           </th>
           <th

--- a/src/components/pages/Styleguide/Styleguide.jsx
+++ b/src/components/pages/Styleguide/Styleguide.jsx
@@ -7,6 +7,7 @@ import Titles from 'components/layout/Titles/Titles'
 import StyleguideAgenda from './StyleguideAgenda'
 import StyleguideBanners from './StyleguideElements/StyleguideBanners'
 import StyleguideButtons from './StyleguideElements/StyleguideButtons'
+import StyleguideCheckboxes from './StyleguideElements/StyleguideCheckboxes'
 import StyleguideInputText from './StyleguideElements/StyleguideInputText'
 import StyleguideSelect from './StyleguideElements/StyleguideSelect'
 import StyleguideTitles from './StyleguideElements/StyleguideTitles'
@@ -41,6 +42,12 @@ const Styleguide = () => (
       componentName="Select"
     />
     <StyleguideSelect />
+
+    <StyleguideTitle
+      className="sg-select"
+      componentName="StyleguideCheckboxes"
+    />
+    <StyleguideCheckboxes />
 
     <StyleguideTitle
       className="sg-banner"

--- a/src/components/pages/Styleguide/StyleguideElements/StyleguideCheckboxes.jsx
+++ b/src/components/pages/Styleguide/StyleguideElements/StyleguideCheckboxes.jsx
@@ -1,0 +1,42 @@
+import React, { useCallback, useState } from 'react'
+
+import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
+
+const StyleguideCheckboxes = () => {
+  const [checked, setChecked] = useState(false)
+
+  const checkboxeSnippet = String.raw`
+    <CheckboxInput
+      onChange={handleOnChange}
+      value="checkbox_value"
+      name="checkbox_name"
+      label="Checkbox label"
+      checked={checked}
+    />
+  `
+
+  const handleOnChange = useCallback(() => setChecked(() => !checked), [checked])
+
+  return (
+    <div className="styleguide-select">
+      <div className="flex-block">
+        <CheckboxInput
+          checked={checked}
+          label="Checkbox label"
+          name="checkbox_name"
+          onChange={handleOnChange}
+          value="checkbox_value"
+        />
+        <div className="it-description">
+          <pre className="it-icon-snippet">
+            <code>
+              {checkboxeSnippet}
+            </code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default StyleguideCheckboxes

--- a/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
+++ b/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
@@ -1,4 +1,4 @@
-input[type="checkbox"] {
+.input-checkbox {
   -moz-appearance: none;
   -webkit-appearance: none;
   border: 2px solid $grey-dark;
@@ -59,5 +59,10 @@ input[type="checkbox"] {
       border-color: $grey-medium;
       opacity: 1;
     }
+  }
+}
+.input-checkbox-label {
+  &.label-hidden {
+    display: none;
   }
 }


### PR DESCRIPTION
Les style de tout les elements de formulaires sont un peu eclaté, on à :
*  `field-checkbox`, utilisé par final form. (styles/global/form.scss)
* input[type=checkbox], défini par bulma (styles/vendors/_bulma.scss)

J'ai:
* scoper le styles de notre _CheckboxInput.scss, 
* ajouter un composants & sont example dans le styleguide
* ajouter nouvelle classe "input-checkbox" sur le field final-form (composants/layout/form/fields/CheckboxField.js) 