### PR TITLE
(PC-5273) Fix offerer name not being displayed on some offers

### DIFF
--- a/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
+++ b/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
@@ -66,7 +66,9 @@ export const mapStateToProps = (state, ownProps) => {
   )
 
   const offerers = selectOfferers(state)
-  const offerer = selectOffererById(state, offererId)
+  const offerer = venue
+    ? venue.managingOfferer || selectOffererById(state, offererId)
+    : selectOffererById(state, offererId)
   const stocks = selectStocksByOfferId(state, offerId)
   const url = get(state, 'form.offer.url') || get(offer, 'url')
 

--- a/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
+++ b/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
@@ -63,7 +63,9 @@ export const mapStateToProps = (state, ownProps) => {
   )
 
   const offerers = selectOfferers(state)
-  const offerer = selectOffererById(state, offererId)
+  const offerer = venue
+    ? venue.managingOfferer || selectOffererById(state, offererId)
+    : selectOffererById(state, offererId)
   const stocks = selectStocksByOfferId(state, offerId)
   const url = get(state, 'form.offer.url') || get(offer, 'url')
 


### PR DESCRIPTION
As we only retrieve the 10 first offerers we cannot display offerer name if the user has more
than 10 offerers.
When we can retrieve it from the venue we use it.