### PR TITLE
[quick win] removing of query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "moment-timezone": "^0.5.21",
     "pass-culture-shared": "0.1.7",
     "prop-types": "^15.6.0",
-    "query-string": "5.1.1",
     "re-reselect": "3.4.0",
     "react": "^16.10.2",
     "react-autocomplete": "^1.8.1",

--- a/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
+++ b/src/components/pages/Offer/OfferCreation/OfferCreation.jsx
@@ -20,6 +20,7 @@ import { showModal } from 'store/reducers/modal'
 import { CGU_URL } from 'utils/config'
 import { musicOptions, showOptions } from 'utils/edd'
 import { pluralize } from 'utils/pluralize'
+import { stringify } from 'utils/query-string'
 import {
   mapApiToBrowser,
   translateApiParamsToQueryParams,
@@ -314,9 +315,7 @@ class OfferCreation extends PureComponent {
       searchFiltersParams.creationMode = mapApiToBrowser[creationMode]
     }
 
-    const queryString = new URLSearchParams(
-      translateApiParamsToQueryParams(searchFiltersParams)
-    ).toString()
+    const queryString = stringify(translateApiParamsToQueryParams(searchFiltersParams))
 
     return queryString ? `/offres?${queryString}` : '/offres'
   }

--- a/src/components/pages/Offer/OfferCreation/__specs__/OfferCreationContainer.spec.jsx
+++ b/src/components/pages/Offer/OfferCreation/__specs__/OfferCreationContainer.spec.jsx
@@ -1,7 +1,6 @@
-import { parse as parseQueryString } from 'query-string'
-
 import state from 'components/utils/mocks/state'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
+import { parse } from 'utils/query-string'
 
 import { mapDispatchToProps, mapStateToProps, mergeProps } from '../OfferCreationContainer'
 
@@ -16,7 +15,7 @@ describe('src | OfferCreationContainer', () => {
         },
       },
       query: {
-        parse: queryString => parseQueryString(queryString),
+        parse: queryString => parse(queryString),
       },
       trackCreateOffer: jest.fn(),
       trackModifyOffer: jest.fn(),

--- a/src/components/pages/Offer/OfferEdition/__specs__/OfferEditionContainer.spec.jsx
+++ b/src/components/pages/Offer/OfferEdition/__specs__/OfferEditionContainer.spec.jsx
@@ -1,7 +1,6 @@
-import { parse as parseQueryString } from 'query-string'
-
 import state from 'components/utils/mocks/state'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
+import { parse } from 'utils/query-string'
 
 import { mapDispatchToProps, mapStateToProps, mergeProps } from '../OfferEditionContainer'
 
@@ -16,7 +15,7 @@ describe('components | OfferEdition | OfferEditionContainer', () => {
         },
       },
       query: {
-        parse: queryString => parseQueryString(queryString),
+        parse: queryString => parse(queryString),
       },
       trackCreateOffer: jest.fn(),
       trackModifyOffer: jest.fn(),
@@ -370,7 +369,7 @@ describe('components | OfferEdition | OfferEditionContainer', () => {
             },
           },
           query: {
-            parse: queryString => parseQueryString(queryString),
+            parse: queryString => parse(queryString),
           },
           trackCreateOffer: jest.fn(),
           trackModifyOffer: jest.fn(),

--- a/src/components/pages/Offerers/OfferersContainer.jsx
+++ b/src/components/pages/Offerers/OfferersContainer.jsx
@@ -1,4 +1,3 @@
-import { stringify } from 'query-string'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { assignData, requestData } from 'redux-saga-data'
@@ -23,7 +22,7 @@ export const createApiPath = searchKeyWords => {
     apiQueryParams.keywords = searchKeyWords.join(' ')
   }
 
-  const queryParams = stringify(apiQueryParams)
+  const queryParams = new URLSearchParams(apiQueryParams).toString()
 
   return apiPath + queryParams
 }

--- a/src/components/pages/Offerers/OfferersContainer.jsx
+++ b/src/components/pages/Offerers/OfferersContainer.jsx
@@ -4,12 +4,12 @@ import { assignData, requestData } from 'redux-saga-data'
 import withQueryRouter from 'with-query-router'
 
 import { OFFERERS_API_PATH } from 'config/apiPaths'
-import {} from 'store/selectors/data/featuresSelectors'
 import { closeNotification, showNotificationV1 } from 'store/reducers/notificationReducer'
 import { isAPISireneAvailable } from 'store/selectors/data/featuresSelectors'
 import { selectOfferers } from 'store/selectors/data/offerersSelectors'
 import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { offererNormalizer } from 'utils/normalizers'
+import { stringify } from 'utils/query-string'
 
 import Offerers from './Offerers'
 
@@ -22,7 +22,7 @@ export const createApiPath = searchKeyWords => {
     apiQueryParams.keywords = searchKeyWords.join(' ')
   }
 
-  const queryParams = new URLSearchParams(apiQueryParams).toString()
+  const queryParams = stringify(apiQueryParams)
 
   return apiPath + queryParams
 }

--- a/src/components/pages/Offerers/__specs__/OfferersContainer.spec.jsx
+++ b/src/components/pages/Offerers/__specs__/OfferersContainer.spec.jsx
@@ -178,7 +178,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
           // then
           expect(dispatch).toHaveBeenCalledWith({
             config: {
-              apiPath: '/offerers?keywords=Honor%C3%A9%20Justice&page=0',
+              apiPath: '/offerers?keywords=Honor%C3%A9+Justice&page=0',
               handleFail,
               handleSuccess,
               method: 'GET',
@@ -191,7 +191,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
                 },
               },
             },
-            type: 'REQUEST_DATA_GET_/OFFERERS?KEYWORDS=HONOR%C3%A9%20JUSTICE&PAGE=0',
+            type: 'REQUEST_DATA_GET_/OFFERERS?KEYWORDS=HONOR%C3%A9+JUSTICE&PAGE=0',
           })
         })
       })
@@ -211,7 +211,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
           // then
           expect(dispatch).toHaveBeenCalledWith({
             config: {
-              apiPath: '/offerers?keywords=Club%20Dorothy&page=0',
+              apiPath: '/offerers?keywords=Club+Dorothy&page=0',
               handleFail,
               handleSuccess,
               method: 'GET',
@@ -224,7 +224,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
                 },
               },
             },
-            type: 'REQUEST_DATA_GET_/OFFERERS?KEYWORDS=CLUB%20DOROTHY&PAGE=0',
+            type: 'REQUEST_DATA_GET_/OFFERERS?KEYWORDS=CLUB+DOROTHY&PAGE=0',
           })
         })
       })
@@ -262,7 +262,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
             const result = createApiPath(loadOffererParameters)
 
             // then
-            expect(result).toStrictEqual('/offerers?keywords=example%20keyword')
+            expect(result).toStrictEqual('/offerers?keywords=example+keyword')
           })
         })
       })

--- a/src/repository/pcapi/pcapi.js
+++ b/src/repository/pcapi/pcapi.js
@@ -1,5 +1,6 @@
 import { DEFAULT_SEARCH_FILTERS, DEFAULT_PAGE } from 'components/pages/Offers/_constants'
 import { client } from 'repository/pcapi/pcapiClient'
+import { stringify } from 'utils/query-string'
 
 //
 // offers
@@ -31,7 +32,7 @@ export const loadFilteredOffers = async ({
     periodEndingDate,
   })
 
-  const queryParams = new URLSearchParams(body).toString()
+  const queryParams = stringify(body)
   return client.get(`/offers?${queryParams}`)
 }
 

--- a/src/store/selectors/search.js
+++ b/src/store/selectors/search.js
@@ -1,7 +1,9 @@
 import createCachedSelector from 're-reselect'
 
+import { parse } from 'utils/query-string'
+
 export const searchSelector = createCachedSelector(
   (state, search) => search,
 
-  search => Object.fromEntries(new URLSearchParams(search)) || {}
+  search => parse(search) || {}
 )((state, search) => search || '')

--- a/src/utils/__specs__/query-string.spec.js
+++ b/src/utils/__specs__/query-string.spec.js
@@ -1,0 +1,35 @@
+const { parse, stringify } = require('utils/query-string')
+
+describe('handling of URL', () => {
+  it('should transform queryParams to object / keys-values', () => {
+    // Given
+    const queryParams = '?offerId=ME&stockId=FA&mediation&name=un+titre'
+
+    // When
+    const string = parse(queryParams)
+
+    // Then
+    expect(string).toStrictEqual({
+      offerId: 'ME',
+      stockId: 'FA',
+      mediation: '',
+      name: 'un titre',
+    })
+  })
+
+  it('shoudl transform an object to query string', () => {
+    // Given
+    const queryParams = {
+      offerId: 'ME',
+      stockId: 'FA',
+      mediation: '',
+      name: 'un titre',
+    }
+
+    // When
+    const string = stringify(queryParams)
+
+    // Then
+    expect(string).toBe('offerId=ME&stockId=FA&mediation=&name=un+titre')
+  })
+})

--- a/src/utils/query-string.js
+++ b/src/utils/query-string.js
@@ -1,0 +1,3 @@
+export const parse = queryParams => Object.fromEntries(new URLSearchParams(queryParams))
+
+export const stringify = queryParams => new URLSearchParams(queryParams).toString()

--- a/testcafe/07_stocks.js
+++ b/testcafe/07_stocks.js
@@ -1,4 +1,3 @@
-import { parse } from 'query-string'
 import { Selector } from 'testcafe'
 
 import { getUrlParams } from './helpers/location'
@@ -26,7 +25,7 @@ test('Je peux créer un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(addStockButton)
 
-  let queryParams = parse(await getUrlParams())
+  let queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
 
   await t
     .expect(queryParams.stock)
@@ -35,7 +34,7 @@ test('Je peux créer un stock pour un événement', () => async t => {
     .click(datePickerLastDay)
     .click(submitButton)
 
-  queryParams = parse(await getUrlParams())
+    queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
   await t.expect(queryParams.stock).eql(undefined).expect(stockItem.count).eql(1)
 })
 
@@ -64,10 +63,10 @@ test('Je peux modifier un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(editAnchor)
 
-  let queryParams = parse(await getUrlParams())
+  let queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
   await t
     .expect(queryParams.gestion)
-    .eql(null)
+    .eql('')
     .expect(queryParams[`stock${stock.id}`])
     .eql('modification')
     .expect(beginInput.exists)
@@ -83,7 +82,7 @@ test('Je peux modifier un stock pour un événement', () => async t => {
     .typeText(priceInput, '15')
     .click(submitButton)
 
-  queryParams = parse(await getUrlParams())
+  queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
   await t.expect(queryParams.gestion).eql(null).expect(queryParams.stock).eql(undefined)
 })
 
@@ -100,10 +99,10 @@ test('Je peux supprimer un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(deleteButton).click(deleteButtonConfirmation)
 
-  const queryParams = parse(await getUrlParams())
+  const queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
   await t
     .expect(queryParams.gestion)
-    .eql(null)
+    .eql('')
     .expect(beginInput.exists)
     .notOk()
     .expect(datePicker.exists)

--- a/testcafe/07_stocks.js
+++ b/testcafe/07_stocks.js
@@ -1,5 +1,7 @@
 import { Selector } from 'testcafe'
 
+import { parse } from '../src/utils/query-string'
+
 import { getUrlParams } from './helpers/location'
 import { navigateToOfferAs } from './helpers/navigations'
 import { createUserRole } from './helpers/roles'
@@ -25,7 +27,7 @@ test('Je peux créer un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(addStockButton)
 
-  let queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
+  let queryParams = parse(await getUrlParams())
 
   await t
     .expect(queryParams.stock)
@@ -34,7 +36,7 @@ test('Je peux créer un stock pour un événement', () => async t => {
     .click(datePickerLastDay)
     .click(submitButton)
 
-    queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
+  queryParams = parse(await getUrlParams())
   await t.expect(queryParams.stock).eql(undefined).expect(stockItem.count).eql(1)
 })
 
@@ -63,7 +65,7 @@ test('Je peux modifier un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(editAnchor)
 
-  let queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
+  let queryParams = parse(await getUrlParams())
   await t
     .expect(queryParams.gestion)
     .eql('')
@@ -82,8 +84,8 @@ test('Je peux modifier un stock pour un événement', () => async t => {
     .typeText(priceInput, '15')
     .click(submitButton)
 
-  queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
-  await t.expect(queryParams.gestion).eql(null).expect(queryParams.stock).eql(undefined)
+  queryParams = parse(await getUrlParams())
+  await t.expect(queryParams.gestion).eql('').expect(queryParams.stock).eql(undefined)
 })
 
 test('Je peux supprimer un stock pour un événement', () => async t => {
@@ -99,7 +101,7 @@ test('Je peux supprimer un stock pour un événement', () => async t => {
 
   await t.click(manageStockAnchor).click(deleteButton).click(deleteButtonConfirmation)
 
-  const queryParams = Object.fromEntries(new URLSearchParams(await getUrlParams()))
+  const queryParams = parse(await getUrlParams())
   await t
     .expect(queryParams.gestion)
     .eql('')


### PR DESCRIPTION
`query-string` est devenu absolète depuis que [URLSearchParams](https://developer.mozilla.org/fr/docs/Web/API/URLSearchParams) existe.
[Pourquoi on passe de `null` à '' dans les testcafé ?](https://github.com/sindresorhus/query-string/blob/master/index.js#L250)