### PR TITLE
OfferEdition : Fix refresh offer on form submit

### DIFF
--- a/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
+++ b/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
@@ -77,7 +77,6 @@ class OfferEdition extends PureComponent {
     } = this.props
 
     const { search } = location
-
     if (prevProps.location.search !== search) {
       this.handleShowStocksManager()
       return
@@ -195,15 +194,15 @@ class OfferEdition extends PureComponent {
 
   onHandleFormSuccess = () => {
     const {
+      loadOffer,
       offer,
       trackModifyOffer,
-      history,
       showOfferModificationValidationNotification,
     } = this.props
 
     trackModifyOffer(offer.id)
     showOfferModificationValidationNotification()
-    history.push(`/offres/${offer.id}`)
+    loadOffer(offer.id)
   }
 
   handleShowStocksManager = () => {

--- a/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
@@ -82,7 +82,7 @@ describe('components | OfferEdition', () => {
         wrapper.instance().onHandleFormSuccess({})
 
         // then
-        expect(history.push).toHaveBeenCalledWith('/offres/26B')
+        expect(props.loadOffer).toHaveBeenCalledWith(props.offer.id)
       })
 
       it('should display a validation modification notification', () => {


### PR DESCRIPTION
  Since we don't reload the pages using "withLoginRequired" hoc,
history.push on the same route will not be catch by react-router as a
update.
Therefor it'll not execute "componentDidUpdate" and reload the offer.

Here we force offer reoad using loadOffer() submit success