### PR TITLE
Rlecellier/pc 5336 fix offer edition offer refresh on submit

### DIFF
--- a/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
+++ b/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
@@ -195,6 +195,7 @@ class OfferEdition extends PureComponent {
 
   onHandleFormSuccess = () => {
     const {
+      dispatch,
       offer,
       trackModifyOffer,
       history,
@@ -203,6 +204,8 @@ class OfferEdition extends PureComponent {
 
     trackModifyOffer(offer.id)
     showOfferModificationValidationNotification()
+
+    dispatch(resetForm())
     history.push(`/offres/${offer.id}`)
   }
 

--- a/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
+++ b/src/components/pages/Offer/OfferEdition/OfferEdition.jsx
@@ -77,6 +77,7 @@ class OfferEdition extends PureComponent {
     } = this.props
 
     const { search } = location
+
     if (prevProps.location.search !== search) {
       this.handleShowStocksManager()
       return
@@ -194,15 +195,15 @@ class OfferEdition extends PureComponent {
 
   onHandleFormSuccess = () => {
     const {
-      loadOffer,
       offer,
       trackModifyOffer,
+      history,
       showOfferModificationValidationNotification,
     } = this.props
 
     trackModifyOffer(offer.id)
     showOfferModificationValidationNotification()
-    loadOffer(offer.id)
+    history.push(`/offres/${offer.id}`)
   }
 
   handleShowStocksManager = () => {

--- a/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offer/OfferEdition/__specs__/OfferEdition.spec.jsx
@@ -82,7 +82,7 @@ describe('components | OfferEdition', () => {
         wrapper.instance().onHandleFormSuccess({})
 
         // then
-        expect(props.loadOffer).toHaveBeenCalledWith(props.offer.id)
+        expect(history.push).toHaveBeenCalledWith('/offres/26B')
       })
 
       it('should display a validation modification notification', () => {


### PR DESCRIPTION
Voila le vrai fix, celui qui fonctionne.
Alors même que offer est rechargé lorsqu'on reviens sur la page de création, les valeurs du formulaire dans le store restaient inchangé.