### PR TITLE
(PC-5431): Service worker vide

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,0 +1,8 @@
+// Empty service worker so the build creates and serves this empty file
+// If a former bundle still has a service worker and request for the /service-worker.js file
+// it won't fail thanks to the empty file.
+
+// Required following https://create-react-app.dev/docs/making-a-progressive-web-app/#customization
+// eslint-disable-next-line no-restricted-globals
+// eslint-disable-next-line no-unused-vars
+const ignored = self.__WB_MANIFEST


### PR DESCRIPTION
This PR https://github.com/pass-culture/pass-culture-pro/pull/862 unresgistered the service worker.
But for a client with former bundle, its service worker is still in function. And before being unregistered, it tries to load the `service-worker.js` file.

This PR creates an empty service worker so our builder creates and serves it as `/service-worker.js`.
Former bundle won't fail when requesting this file.