### PR TITLE
[quick win] adding of lazy loading on offer images

### DIFF
--- a/src/components/layout/Thumb.jsx
+++ b/src/components/layout/Thumb.jsx
@@ -8,6 +8,7 @@ const Thumb = ({ url, alt = '' }) => {
     <img
       alt={alt}
       className="offer-thumb"
+      loading="lazy"
       src={url}
     />
   ) : (


### PR DESCRIPTION
Le seul endroit où il y a un défilement d'image est sur la page des offres.
Le [lazy loading](https://developer.mozilla.org/fr/docs/Web/HTML/Element/img#attr-loading) permet de télécharger les images uniquement quand on scrolle la page. On gagne un peu de temps au chargement de la page.