### PR TITLE
(PC-5007) : do not use new CheckboxInput everywhere for now

### DIFF
--- a/src/components/layout/form/fields/CheckboxField.jsx
+++ b/src/components/layout/form/fields/CheckboxField.jsx
@@ -10,7 +10,6 @@ class CheckboxField extends PureComponent {
       <div>
         <input
           {...input}
-          className="input-checkbox"
           defaultChecked={checked}
           id={id}
           type="checkbox"

--- a/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
 
 import Icon from 'components/layout/Icon'
-import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 
 import { getBookingStatusDisplayInformations } from '../CellsFormatter/utils/bookingStatusConverter'
 
@@ -140,15 +139,17 @@ class FilterByBookingStatus extends Component {
               </div>
               {bookingStatuses.map(bookingStatus => (
                 <Fragment key={bookingStatus.value}>
-                  <CheckboxInput
-                    checked={!bookingStatusFilters.includes(bookingStatus.value)}
-                    data-status-filter-tooltip
-                    id={`bs-${bookingStatus.value}`}
-                    label={bookingStatus.title}
-                    labelAttributes={{ 'data-status-filter-tooltip': true }}
-                    name={bookingStatus.value}
-                    onChange={this.handleCheckboxChange}
-                  />
+                  <label data-status-filter-tooltip>
+                    <input
+                      checked={!bookingStatusFilters.includes(bookingStatus.value)}
+                      data-status-filter-tooltip
+                      id={`bs-${bookingStatus.value}`}
+                      name={bookingStatus.value}
+                      onChange={this.handleCheckboxChange}
+                      type="checkbox"
+                    />
+                    {bookingStatus.title}
+                  </label>
                 </Fragment>
               ))}
             </div>

--- a/src/components/pages/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Filters/__specs__/FilterByBookingStatus.spec.jsx
@@ -106,7 +106,6 @@ describe('components | FilterByBookingStatus', () => {
       expect(checkbox).toHaveLength(2)
       expect(checkbox.at(0).props()).toStrictEqual({
         checked: true,
-        className: 'input-checkbox',
         'data-status-filter-tooltip': true,
         id: 'bs-booked',
         name: 'booked',
@@ -115,7 +114,6 @@ describe('components | FilterByBookingStatus', () => {
       })
       expect(checkbox.at(1).props()).toStrictEqual({
         checked: true,
-        className: 'input-checkbox',
         'data-status-filter-tooltip': true,
         id: 'bs-validated',
         name: 'validated',

--- a/src/components/pages/Offers/OfferItem/OfferItem.jsx
+++ b/src/components/pages/Offers/OfferItem/OfferItem.jsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import Icon from 'components/layout/Icon'
-import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 import Thumb from 'components/layout/Thumb'
 import { isOfferFullyBooked } from 'components/pages/Offers/domain/isOfferFullyBooked'
 import { computeVenueDisplayName } from 'repository/venuesService'
@@ -61,15 +60,14 @@ const OfferItem = ({ disabled, offer, stocks, venue, isSelected, selectOffer }) 
   return (
     <tr className={`offer-item ${isOfferInactiveOrExpired ? 'inactive' : ''} offer-row`}>
       <td className="select-column">
-        <CheckboxInput
+        <input
           checked={isSelected}
           className="select-offer-checkbox"
           data-testid={`select-offer-${offer.id}`}
           disabled={disabled}
-          hiddenLabel
           id={`select-offer-${offer.id}`}
-          label={`Selectionner l'offre ${offer.name}`}
           onChange={handleOnChangeSelected}
+          type="checkbox"
         />
       </td>
       <td className="thumb-column">

--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -4,7 +4,6 @@ import React, { Fragment, PureComponent } from 'react'
 import { Link } from 'react-router-dom'
 
 import Icon from 'components/layout/Icon'
-import { CheckboxInput } from 'components/layout/inputs/CheckboxInput/CheckboxInput'
 import Select from 'components/layout/inputs/Select'
 import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import Main from 'components/layout/Main'
@@ -443,14 +442,14 @@ class Offers extends PureComponent {
       <thead>
         <tr>
           <th className="th-checkbox">
-            <CheckboxInput
+            <input
               checked={areAllOffersSelected}
-              className="input-checkbox select-offer-checkbox"
+              className="select-offer-checkbox"
               disabled={this.isAdminForbidden(savedSearchFilters) || !offers.length}
-              hiddenLabel
               id="select-offer-checkbox"
               label="Selectionner toutes les offres"
               onChange={this.selectAllOffers}
+              type="checkbox"
             />
           </th>
           <th

--- a/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
+++ b/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
@@ -1,3 +1,4 @@
+input[type="checkbox"],
 .input-checkbox {
   -moz-appearance: none;
   -webkit-appearance: none;


### PR DESCRIPTION
  This revert changes on components from e781f3145513e10646db7f3fd6d4bbb085cd7cbd
We only keep the "add to styleguide" part