### PR TITLE
[Quick Win]: Renaming booking table with less generic names

### DIFF
--- a/src/components/pages/Bookings/BookingsRecapTable/Table/Body/TableBody.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/Body/TableBody.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Body = ({ page, prepareRow, tableBodyProps }) => {
+const TableBody = ({ page, prepareRow, tableBodyProps }) => {
   return (
     <tbody
       className="bookings-body"
@@ -31,10 +31,10 @@ const Body = ({ page, prepareRow, tableBodyProps }) => {
   )
 }
 
-Body.propTypes = {
+TableBody.propTypes = {
   page: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   prepareRow: PropTypes.func.isRequired,
-  tableBodyProps: PropTypes.shape().isRequired
+  tableBodyProps: PropTypes.shape().isRequired,
 }
 
-export default Body
+export default TableBody

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/Head/TableHead.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/Head/TableHead.jsx
@@ -12,7 +12,7 @@ const handleOnKeyDown = (column, selector) => event => {
   }
 }
 
-const Head = ({ headerGroups }) => {
+const TableHead = ({ headerGroups }) => {
   return (
     <thead className="bookings-head">
       {headerGroups.map(headerGroup => (
@@ -63,7 +63,7 @@ const Head = ({ headerGroups }) => {
   )
 }
 
-Head.propTypes = {
+TableHead.propTypes = {
   headerGroups: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
@@ -78,4 +78,4 @@ Head.propTypes = {
   ).isRequired,
 }
 
-export default Head
+export default TableHead

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/Head/__specs__/Head.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/Head/__specs__/Head.spec.jsx
@@ -3,10 +3,9 @@ import React from 'react'
 
 import Icon from 'components/layout/Icon'
 
-import Head from '../Head'
+import TableHead from '../TableHead'
 
-
-describe('components | pages | Table | Head', () => {
+describe('components | pages | TableWrapper | TableHead', () => {
   it('should render one line with all columns', () => {
     // Given
     const props = {
@@ -42,22 +41,12 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     expect(wrapper.find('th')).toHaveLength(2)
-    expect(
-      wrapper
-        .find('th')
-        .at(0)
-        .text()
-    ).toBe('Offres')
-    expect(
-      wrapper
-        .find('th')
-        .at(1)
-        .text()
-    ).toBe('Beneficiaires')
+    expect(wrapper.find('th').at(0).text()).toBe('Offres')
+    expect(wrapper.find('th').at(1).text()).toBe('Beneficiaires')
   })
 
   it('should return no line when there is no headers', () => {
@@ -67,7 +56,7 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     expect(wrapper.find('tr')).toHaveLength(0)
@@ -90,7 +79,7 @@ describe('components | pages | Table | Head', () => {
               )),
               getHeaderProps: jest.fn(),
               getSortByToggleProps: jest.fn(),
-              canSort: true
+              canSort: true,
             },
           ],
         },
@@ -98,7 +87,7 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     const firstColumn = wrapper.find('th')
@@ -126,7 +115,7 @@ describe('components | pages | Table | Head', () => {
               )),
               getHeaderProps: jest.fn(),
               getSortByToggleProps: jest.fn(),
-              canSort: false
+              canSort: false,
             },
           ],
         },
@@ -134,7 +123,7 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     const firstColumn = wrapper.find('th')
@@ -162,7 +151,7 @@ describe('components | pages | Table | Head', () => {
               getHeaderProps: jest.fn(),
               getSortByToggleProps: jest.fn(),
               canSort: true,
-              isSorted: true
+              isSorted: true,
             },
           ],
         },
@@ -170,7 +159,7 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     const firstColumn = wrapper.find('th')
@@ -200,7 +189,7 @@ describe('components | pages | Table | Head', () => {
               getSortByToggleProps: jest.fn(),
               canSort: true,
               isSorted: true,
-              isSortedDesc: true
+              isSortedDesc: true,
             },
           ],
         },
@@ -208,7 +197,7 @@ describe('components | pages | Table | Head', () => {
     }
 
     // When
-    const wrapper = shallow(<Head {...props} />)
+    const wrapper = shallow(<TableHead {...props} />)
 
     // Then
     const firstColumn = wrapper.find('th')

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/Paginate/TablePagination.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/Paginate/TablePagination.jsx
@@ -3,41 +3,42 @@ import React from 'react'
 
 import Icon from 'components/layout/Icon'
 
-const Paginate = ({ canNextPage,
+const TablePagination = ({
+  canNextPage,
   canPreviousPage,
   currentPage,
   previousPage,
   nbPages,
-  nextPage
+  nextPage,
 }) => (
-  <div className='paginate-wrapper'>
+  <div className="paginate-wrapper">
     <button
       disabled={!canPreviousPage}
       onClick={previousPage}
-      type='button'
+      type="button"
     >
-      <Icon svg='ico-left-arrow' />
+      <Icon svg="ico-left-arrow" />
     </button>
     <span>
-      { `Page ${currentPage}/${nbPages}` }
+      {`Page ${currentPage}/${nbPages}`}
     </span>
     <button
       disabled={!canNextPage}
       onClick={nextPage}
-      type='button'
+      type="button"
     >
-      <Icon svg='ico-right-arrow' />
+      <Icon svg="ico-right-arrow" />
     </button>
   </div>
 )
 
-Paginate.propTypes = {
+TablePagination.propTypes = {
   canNextPage: PropTypes.bool.isRequired,
   canPreviousPage: PropTypes.bool.isRequired,
   currentPage: PropTypes.number.isRequired,
   nbPages: PropTypes.number.isRequired,
   nextPage: PropTypes.func.isRequired,
-  previousPage: PropTypes.func.isRequired
+  previousPage: PropTypes.func.isRequired,
 }
 
-export default Paginate
+export default TablePagination

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/Paginate/__specs__/Paginate.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/Paginate/__specs__/Paginate.spec.jsx
@@ -3,9 +3,9 @@ import React from 'react'
 
 import Icon from 'components/layout/Icon'
 
-import Paginate from '../Paginate'
+import TablePagination from '../TablePagination'
 
-describe('components | Paginate', () => {
+describe('components | TablePagination', () => {
   let props
 
   beforeEach(() => {
@@ -25,7 +25,7 @@ describe('components | Paginate', () => {
       props.canPreviousPage = true
 
       // when
-      const wrapper = shallow(<Paginate {...props} />)
+      const wrapper = shallow(<TablePagination {...props} />)
 
       // then
       const buttons = wrapper.find('button').find(Icon)
@@ -40,7 +40,7 @@ describe('components | Paginate', () => {
       props.nbPages = 2
 
       // when
-      const wrapper = shallow(<Paginate {...props} />)
+      const wrapper = shallow(<TablePagination {...props} />)
 
       // then
       const currentPage = wrapper.find({ children: 'Page 1/2' })
@@ -52,7 +52,7 @@ describe('components | Paginate', () => {
       props.canNextPage = true
 
       // when
-      const wrapper = shallow(<Paginate {...props} />)
+      const wrapper = shallow(<TablePagination {...props} />)
 
       // then
       const buttons = wrapper.find('button').find(Icon)
@@ -66,7 +66,7 @@ describe('components | Paginate', () => {
     it('should go back to previous page when click on previous button', () => {
       // given
       props.canPreviousPage = true
-      const wrapper = shallow(<Paginate {...props} />)
+      const wrapper = shallow(<TablePagination {...props} />)
       const buttons = wrapper.find('button')
       const previousButton = buttons.at(0)
 
@@ -80,7 +80,7 @@ describe('components | Paginate', () => {
     it('should go to next page when click on next button', () => {
       // given
       props.canNextPage = true
-      const wrapper = shallow(<Paginate {...props} />)
+      const wrapper = shallow(<TablePagination {...props} />)
       const buttons = wrapper.find('button')
       const nextButton = buttons.at(1)
 

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/TableFrame.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/TableFrame.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { usePagination, useSortBy, useTable } from 'react-table'
 
-import Table from './Table'
+import TableWrapper from './TableWrapper'
 
 const TableFrame = ({
   columns,
@@ -38,7 +38,7 @@ const TableFrame = ({
   const pageCount = Math.ceil(nbBookings / nbBookingsPerPage)
 
   return (
-    <Table
+    <TableWrapper
       canNextPage={canNextPage}
       canPreviousPage={canPreviousPage}
       getTableBodyProps={getTableBodyProps}

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/TableWrapper.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/TableWrapper.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import Body from './Body/Body'
-import Head from './Head/Head'
-import Paginate from './Paginate/Paginate'
+import TableBody from './Body/TableBody'
+import TableHead from './Head/TableHead'
+import TablePagination from './Paginate/TablePagination'
 
-class Table extends React.Component {
+class TableWrapper extends React.Component {
   goToNextPage = () => {
     const { pageIndex, nextPage, updateCurrentPage } = this.props
     nextPage()
@@ -36,14 +36,14 @@ class Table extends React.Component {
           className="bookings-table"
           {...getTableProps()}
         >
-          <Head headerGroups={headerGroups} />
-          <Body
+          <TableHead headerGroups={headerGroups} />
+          <TableBody
             page={page}
             prepareRow={prepareRow}
             tableBodyProps={getTableBodyProps()}
           />
         </table>
-        <Paginate
+        <TablePagination
           canNextPage={canNextPage}
           canPreviousPage={canPreviousPage}
           currentPage={pageIndex + 1}
@@ -56,7 +56,7 @@ class Table extends React.Component {
   }
 }
 
-Table.propTypes = {
+TableWrapper.propTypes = {
   canNextPage: PropTypes.bool.isRequired,
   canPreviousPage: PropTypes.bool.isRequired,
   getTableBodyProps: PropTypes.func.isRequired,
@@ -71,4 +71,4 @@ Table.propTypes = {
   updateCurrentPage: PropTypes.func.isRequired,
 }
 
-export default Table
+export default TableWrapper

--- a/src/components/pages/Bookings/BookingsRecapTable/Table/__specs__/TableFrame.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/Table/__specs__/TableFrame.spec.jsx
@@ -2,10 +2,9 @@ import { mount } from 'enzyme'
 import React from 'react'
 import * as reactTable from 'react-table'
 
-import Head from '../Head/Head'
-import Paginate from '../Paginate/Paginate'
+import TableHead from '../Head/TableHead'
+import TablePagination from '../Paginate/TablePagination'
 import TableFrame from '../TableFrame'
-
 
 const CellMock = ({ offer: { offer_name: offerName } }) => (
   <span>
@@ -14,7 +13,7 @@ const CellMock = ({ offer: { offer_name: offerName } }) => (
 )
 
 describe('components | TableFrame', () => {
-  it('should render a Head component with the right props', () => {
+  it('should render a TableHead component with the right props', () => {
     // Given
     const mockedValues = {
       canPreviousPage: true,
@@ -91,7 +90,7 @@ describe('components | TableFrame', () => {
     const table = mount(<TableFrame {...props} />)
 
     // Then
-    const tableHead = table.find(Head)
+    const tableHead = table.find(TableHead)
     expect(tableHead).toHaveLength(1)
     expect(tableHead.props()).toStrictEqual({
       headerGroups: mockedValues.headerGroups,
@@ -108,7 +107,7 @@ describe('components | TableFrame', () => {
           headerTitle: 'Stock',
           accessor: 'stock',
           // eslint-disable-next-line react/display-name, react/no-multi-comp
-          Cell: function({ value }) {
+          Cell: function ({ value }) {
             return <CellMock offer={value} />
           },
           getHeaderProps: jest.fn(),
@@ -119,7 +118,7 @@ describe('components | TableFrame', () => {
           headerTitle: 'Beneficiaire',
           accessor: 'beneficiary',
           // eslint-disable-next-line react/display-name, react/no-multi-comp
-          Cell: function({ value }) {
+          Cell: function ({ value }) {
             return <CellMock offer={value} />
           },
           getHeaderProps: jest.fn(),
@@ -167,7 +166,7 @@ describe('components | TableFrame', () => {
   })
 
   describe('pagination', () => {
-    it('should render a Paginate component with the right props', () => {
+    it('should render a TablePagination component with the right props', () => {
       // Given
       const props = {
         columns: [
@@ -176,7 +175,7 @@ describe('components | TableFrame', () => {
             headerTitle: 'Stock',
             accessor: 'stock',
             // eslint-disable-next-line react/display-name, react/no-multi-comp
-            Cell: function({ value }) {
+            Cell: function ({ value }) {
               return <CellMock offer={value} />
             },
             getHeaderProps: jest.fn(),
@@ -201,7 +200,7 @@ describe('components | TableFrame', () => {
       const wrapper = mount(<TableFrame {...props} />)
 
       // Then
-      const paginate = wrapper.find(Paginate)
+      const paginate = wrapper.find(TablePagination)
       expect(paginate).toHaveLength(1)
       expect(paginate.props()).toStrictEqual({
         canNextPage: true,
@@ -222,7 +221,7 @@ describe('components | TableFrame', () => {
             headerTitle: 'Stock',
             accessor: 'stock',
             // eslint-disable-next-line react/display-name, react/no-multi-comp
-            Cell: function({ value }) {
+            Cell: function ({ value }) {
               return <CellMock offer={value} />
             },
             getHeaderProps: jest.fn(),
@@ -265,7 +264,7 @@ describe('components | TableFrame', () => {
             headerTitle: 'Stock',
             accessor: 'stock',
             // eslint-disable-next-line react/display-name, react/no-multi-comp
-            Cell: function({ value }) {
+            Cell: function ({ value }) {
               return <CellMock offer={value} />
             },
             getHeaderProps: jest.fn(),
@@ -286,7 +285,7 @@ describe('components | TableFrame', () => {
         updateCurrentPage: jest.fn(),
       }
       const wrapper = mount(<TableFrame {...props} />)
-      const paginate = wrapper.find(Paginate)
+      const paginate = wrapper.find(TablePagination)
       const nextPageButton = paginate.find('button').at(1)
 
       // When
@@ -309,7 +308,7 @@ describe('components | TableFrame', () => {
             headerTitle: 'Stock',
             accessor: 'stock',
             // eslint-disable-next-line react/display-name, react/no-multi-comp
-            Cell: function({ value }) {
+            Cell: function ({ value }) {
               return <CellMock offer={value} />
             },
             getHeaderProps: jest.fn(),
@@ -330,7 +329,7 @@ describe('components | TableFrame', () => {
         updateCurrentPage: jest.fn(),
       }
       const wrapper = mount(<TableFrame {...props} />)
-      const paginate = wrapper.find(Paginate)
+      const paginate = wrapper.find(TablePagination)
 
       // When
       const previousPageButton = paginate.find('button').at(0)

--- a/src/components/pages/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/__specs__/BookingsRecapTable.spec.jsx
@@ -15,10 +15,9 @@ import Filters from '../Filters/Filters'
 import Header from '../Header/Header'
 import { NB_BOOKINGS_PER_PAGE } from '../NB_BOOKINGS_PER_PAGE'
 import NoFilteredBookings from '../NoFilteredBookings/NoFilteredBookings'
-import Paginate from '../Table/Paginate/Paginate'
+import TablePagination from '../Table/Paginate/TablePagination'
 import TableFrame from '../Table/TableFrame'
 import filterBookingsRecap from '../utils/filterBookingsRecap'
-
 
 jest.mock('../NB_BOOKINGS_PER_PAGE', () => ({
   NB_BOOKINGS_PER_PAGE: 1,
@@ -125,7 +124,7 @@ describe('components | BookingsRecapTable', () => {
           booking_is_duo: true,
           venue: {
             identifier: 'AE',
-            name: 'Librairie Kléber'
+            name: 'Librairie Kléber',
           },
           booking_status_history: [
             {
@@ -181,7 +180,7 @@ describe('components | BookingsRecapTable', () => {
           booking_is_duo: true,
           venue: {
             identifier: 'AE',
-            name: 'Librairie Kléber'
+            name: 'Librairie Kléber',
           },
           booking_status_history: [
             {
@@ -225,7 +224,7 @@ describe('components | BookingsRecapTable', () => {
         booking_is_duo: true,
         venue: {
           identifier: 'AE',
-          name: 'Librairie Kléber'
+          name: 'Librairie Kléber',
         },
         booking_status_history: [
           {
@@ -293,7 +292,7 @@ describe('components | BookingsRecapTable', () => {
         booking_status: 'validated',
         venue: {
           identifier: 'AE',
-          name: 'Librairie Kléber'
+          name: 'Librairie Kléber',
         },
         booking_status_history: [
           {
@@ -410,7 +409,7 @@ describe('components | BookingsRecapTable', () => {
         booking_is_duo: true,
         venue: {
           identifier: 'AE',
-          name: 'Librairie Kléber'
+          name: 'Librairie Kléber',
         },
         booking_status_history: [
           {
@@ -439,7 +438,7 @@ describe('components | BookingsRecapTable', () => {
         booking_is_duo: true,
         venue: {
           identifier: 'AE',
-          name: 'Librairie Kléber'
+          name: 'Librairie Kléber',
         },
         booking_status_history: [
           {
@@ -461,7 +460,7 @@ describe('components | BookingsRecapTable', () => {
 
     // When
     const wrapper = mount(<BookingsRecapTable {...props} />)
-    const paginate = wrapper.find(Paginate)
+    const paginate = wrapper.find(TablePagination)
     const nextPageButton = paginate.find('button').at(1)
     nextPageButton.simulate('click')
 
@@ -658,7 +657,7 @@ describe('components | BookingsRecapTable', () => {
       booking_is_duo: false,
       venue: {
         identifier: 'AE',
-        name: 'Librairie Kléber'
+        name: 'Librairie Kléber',
       },
       booking_status_history: [
         {
@@ -711,7 +710,7 @@ describe('components | BookingsRecapTable', () => {
           booking_is_duo: false,
           venue: {
             identifier: 'AE',
-            name: 'Librairie Kléber'
+            name: 'Librairie Kléber',
           },
           booking_status_history: [
             {
@@ -734,10 +733,7 @@ describe('components | BookingsRecapTable', () => {
     await offerNameInput.simulate('change', { target: { value: 'not findable' } })
 
     const selectedDate = moment('2020-05-20')
-    const offerDatePicker = wrapper
-      .find(Filters)
-      .find(DatePicker)
-      .at(0)
+    const offerDatePicker = wrapper.find(Filters).find(DatePicker).at(0)
     await offerDatePicker.simulate('change', selectedDate)
 
     const noFilteredBookings = wrapper.find(NoFilteredBookings)
@@ -751,10 +747,7 @@ describe('components | BookingsRecapTable', () => {
     // Then
     const offerName = wrapper.find(Filters).find({ placeholder: "Rechercher par nom d'offre" })
     expect(offerName.text()).toBe('')
-    const offerDate = wrapper
-      .find(Filters)
-      .find(DatePicker)
-      .at(0)
+    const offerDate = wrapper.find(Filters).find(DatePicker).at(0)
     expect(offerDate.prop('selected')).toBe(EMPTY_FILTER_VALUE)
   })
 
@@ -860,7 +853,7 @@ describe('components | BookingsRecapTable', () => {
       booking_is_duo: true,
       venue: {
         identifier: 'AE',
-        name: 'Librairie Kléber'
+        name: 'Librairie Kléber',
       },
       booking_status_history: [
         {
@@ -905,7 +898,7 @@ describe('components | BookingsRecapTable', () => {
         },
       ],
     }
-    const paginate = wrapper.find(Paginate)
+    const paginate = wrapper.find(TablePagination)
     const nextPageButton = paginate.find('button').at(1)
     nextPageButton.simulate('click')
 


### PR DESCRIPTION
actuellement on a des composants qui s'appellent Head, Table, Paginate, Body, ce qui peut générer des warnings car ils se rapprochent de noms de balises standards HTML et en plus sont peu explicites
Ce quick win les renomme juste