### PR TITLE
(PC-5333) : Fix offer form refresh when a mediation is add.

### DIFF
--- a/src/components/pages/Mediation/Mediation.jsx
+++ b/src/components/pages/Mediation/Mediation.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom'
 import Main from 'components/layout/Main'
 import Titles from 'components/layout/Titles/Titles'
 import UploadThumbContainer from 'components/layout/UploadThumb/UploadThumbContainer'
+import { resetForm } from 'store/reducers/form'
 import { ASSETS_URL } from 'utils/config'
 
 import CanvasTools from '../../../utils/canvas'
@@ -80,9 +81,10 @@ class Mediation extends PureComponent {
   }
 
   handleSuccessData = () => {
-    const { history, offer, showOfferModificationValidationNotification } = this.props
+    const { dispatch, history, offer, showOfferModificationValidationNotification } = this.props
 
     this.setState({ isLoading: false }, () => {
+      dispatch(resetForm())
       history.push(`/offres/${offer.id}`)
       showOfferModificationValidationNotification()
     })

--- a/src/components/pages/Mediation/MediationContainer.js
+++ b/src/components/pages/Mediation/MediationContainer.js
@@ -31,6 +31,7 @@ export const mapStateToProps = (state, ownProps) => {
 
 export const mapDispatchToProps = dispatch => {
   return {
+    dispatch,
     getMediation: (mediationId, handleSuccess, handleFail) => {
       dispatch(
         requestData({

--- a/src/components/pages/Mediation/__specs__/Mediation.spec.jsx
+++ b/src/components/pages/Mediation/__specs__/Mediation.spec.jsx
@@ -20,9 +20,11 @@ describe('src | components | pages | Mediation', () => {
 
     props = {
       createOrUpdateMediation,
+      dispatch: jest.fn(),
       getMediation,
       getOffer,
       history: { push: jest.fn() },
+      loadOffer: jest.fn(),
       match: {
         params: {
           offerId: 'AGKA',

--- a/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
+++ b/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
@@ -19,6 +19,7 @@ describe('src | components | pages | MediationContainer', () => {
 
       // then
       expect(result).toStrictEqual({
+        dispatch: expect.any(Function),
         loadOffer: expect.any(Function),
         getMediation: expect.any(Function),
         showOfferModificationErrorNotification: expect.any(Function),


### PR DESCRIPTION
Comme pour le formulaire d'edition d'offre, il faut reset le form de redux-saga-data, sinon le formulaire d'offre se retrouve chargé avec les ancienne données.