### PR TITLE
(PC-5689) :OfferDetails: Add StockButton

### DIFF
--- a/src/components/pages/Offer/OfferDetails/OfferDetails.jsx
+++ b/src/components/pages/Offer/OfferDetails/OfferDetails.jsx
@@ -103,6 +103,7 @@ const OfferDetails = props => {
 
       <div className="content">
         <OfferForm
+          history={history}
           initialValues={formInitialValues}
           isUserAdmin={isUserAdmin}
           offer={offer}

--- a/src/components/pages/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/src/components/pages/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -15,6 +15,7 @@ import MediationsManager from '../../MediationsManager/MediationsManagerContaine
 import { SELECT_DEFAULT_VALUE, TEXT_INPUT_DEFAULT_VALUE } from '../_constants'
 
 import OfferRefundWarning from './OfferRefundWarning'
+import StockButton from './StockButton/StockButtonContainer'
 import SynchronizableProviderInformation from './SynchronizableProviderInformation'
 import TypeTreeSelects from './TypeTreeSelects'
 
@@ -71,7 +72,15 @@ const getOfferConditionalFields = ({
 }
 
 const OfferForm = props => {
-  const { offer, initialValues, onSubmit, onChange, isUserAdmin, submitErrors } = props
+  const {
+    history,
+    initialValues,
+    isUserAdmin,
+    offer,
+    onSubmit,
+    onChange,
+    submitErrors
+  } = props
 
   const [formValues, setFormValues] = useState({})
   const [offererOptions, setOffererOptions] = useState([])
@@ -120,6 +129,7 @@ const OfferForm = props => {
         // in the 10 offerers received by getValidatedOfferers() ?!
         values.offererId = offer.venue.managingOffererId
       }
+
 
       const isSynchronized = isSynchronizedOffer(offer)
       setHasSynchronizedStocks(isSynchronized)
@@ -590,6 +600,15 @@ const OfferForm = props => {
               </h2>
               <div className="form-row">
                 <MediationsManager offer={offer} />
+              </div>
+              <div className="form-row">
+                <StockButton
+                  disabled={readOnlyFields.includes('stocks') ? 'disabled' : ''}
+                  history={history}
+                  offer={offer}
+                  offerTypeType={offerType ? offerType.type : null}
+                  stocks={offer ? offer.stocks : null}
+                />
               </div>
             </section>
           )}

--- a/src/components/pages/Offer/OfferDetails/OfferForm/StockButton/StockButton.jsx
+++ b/src/components/pages/Offer/OfferDetails/OfferForm/StockButton/StockButton.jsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect } from 'react'
+
+import Icon from 'components/layout/Icon'
+import StocksManagerContainer from 'components/pages/Offer/StocksManager/StocksManagerContainer'
+import { showModal } from 'store/reducers/modal'
+import { pluralize } from 'utils/pluralize'
+import { parse as parseQueryString, stringify } from 'utils/query-string'
+
+const StockButton = props => {
+  const { disabled, dispatch, history, offer, offerTypeType, stocks } = props
+  const queryParams = parseQueryString(window.location.search)
+
+  const openStockModal = useCallback(() => {
+    const stockModal = (
+      <StocksManagerContainer
+        offer={offer}
+        offerId={offer.id}
+        selfInit
+      />
+    )
+    dispatch(showModal(stockModal, { isUnclosable: true }))
+  }, [dispatch, offer])
+
+  useEffect(() => {
+    if ('gestion' in queryParams) {
+      openStockModal()
+    }
+  }, [openStockModal, queryParams])
+
+  const handleOnClick = useCallback(
+    event => {
+      event.preventDefault()
+      const search = { ...queryParams, gestion: '' }
+      const stockUrl = `${window.location.pathname}?${stringify(search)}`
+      history.push(stockUrl)
+      openStockModal()
+    },
+    [history, openStockModal, queryParams]
+  )
+
+  const nbStocks = stocks ? stocks.length : 0
+  const isEvent = offerTypeType === 'Event'
+
+  return (
+    <div className="form-row">
+      <div className="field-label">
+        <label htmlFor="input_offers_name">
+          <div className="subtitle">
+            {isEvent ? 'Dates :' : 'Stocks :'}
+          </div>
+        </label>
+      </div>
+      <div className="field-body">
+        <div
+          className="control"
+          style={{ paddingTop: '0.25rem' }}
+        >
+          <span
+            className="nb-dates"
+            style={{ paddingTop: '0.25rem' }}
+          >
+            {pluralize(nbStocks, isEvent ? 'date' : 'stock')}
+          </span>
+          <button
+            className="button is-primary is-outlined is-small manage-stock"
+            disabled={disabled ? 'disabled' : ''}
+            id="manage-stocks"
+            onClick={handleOnClick}
+            type="button"
+          >
+            <span className="icon">
+              <Icon svg="ico-calendar-red" />
+            </span>
+            <span>
+              {isEvent ? 'Gérer les dates et les stocks' : 'Gérer les stocks'}
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default StockButton

--- a/src/components/pages/Offer/OfferDetails/OfferForm/StockButton/StockButtonContainer.jsx
+++ b/src/components/pages/Offer/OfferDetails/OfferForm/StockButton/StockButtonContainer.jsx
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux'
+
+import StockButton from './StockButton'
+
+const mapDispatchToProps = (dispatch) => {
+  return { dispatch }
+}
+
+export default connect(null, mapDispatchToProps)(StockButton)

--- a/src/components/pages/Offer/OfferDetails/OfferForm/StockSection.jsx
+++ b/src/components/pages/Offer/OfferDetails/OfferForm/StockSection.jsx
@@ -35,7 +35,7 @@ const StockSection = (props) => {
 
   return (
     <div className="form-row">
-      <label className="label">
+      <label>
         { labelText }
       </label>
 

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -3,6 +3,8 @@ import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import { getCanSubmit } from 'react-final-form-utils'
 
+import { loadOffer } from 'store/offers/thunks'
+
 import Offer from '../ValueObjects/Offer'
 
 import adaptBookingLimitDatetimeGivenBeginningDatetime from './decorators/adaptBookingLimitDatetimeGivenBeginningDatetime'
@@ -34,6 +36,11 @@ class StockItem extends PureComponent {
     this.tbodyElement = element
   }
 
+  updateStore = () => {
+    const { dispatch, offer } = this.props
+    dispatch(loadOffer(offer.id))
+  }
+
   handleRequestFail = (state, action) => {
     const { handleSetErrors } = this.props
     const {
@@ -61,6 +68,8 @@ class StockItem extends PureComponent {
     if (isEdition) {
       handleEditSuccess()
     }
+
+    this.updateStore()
   }
 
   handleOnFormSubmit = formValues => {

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -73,6 +73,7 @@ export const mapStateToProps = (state, ownProps) => {
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
   return {
+    dispatch,
     updateStockInformations: (stockId, body, handleSuccess, handleFail) => {
       const { query } = ownProps
       const context = query.context({ id: stockId, key: 'stock' })

--- a/src/components/pages/Offer/StocksManager/StocksManager.jsx
+++ b/src/components/pages/Offer/StocksManager/StocksManager.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React, { PureComponent, Fragment } from 'react'
 
 import Titles from 'components/layout/Titles/Titles'
+import { setOffersRecap } from 'store/offers/thunks'
 import { closeModal } from 'store/reducers/modal'
 
 import StockItemContainer from './StockItem/StockItemContainer'
@@ -20,6 +21,11 @@ class StocksManager extends PureComponent {
   }
 
   componentDidMount() {
+    const { dispatch, offer, selfInit } = this.props
+    if (selfInit) {
+      dispatch(setOffersRecap([offer]))
+    }
+
     this.handleShouldPreventCreationOfSecondNotEventStock()
 
     if (this.elem) {
@@ -317,6 +323,7 @@ class StocksManager extends PureComponent {
 
 StocksManager.defaultProps = {
   provider: null,
+  selfInit: false,
   stocks: [],
 }
 
@@ -328,6 +335,7 @@ StocksManager.propTypes = {
   product: PropTypes.shape().isRequired,
   provider: PropTypes.shape(),
   query: PropTypes.shape().isRequired,
+  selfInit: PropTypes.bool,
   stocks: PropTypes.arrayOf(PropTypes.shape()),
 }
 

--- a/src/components/pages/Offer/StocksManager/StocksManagerContainer.js
+++ b/src/components/pages/Offer/StocksManager/StocksManagerContainer.js
@@ -12,7 +12,7 @@ import StocksManager from './StocksManager'
 
 export const mapStateToProps = (state, ownProps) => {
   const { offerId } = ownProps
-  const offer = selectOfferById(state, offerId)
+  const offer = ownProps.offer ? ownProps.offer : selectOfferById(state, offerId)
 
   if (!offer) {
     return {}

--- a/src/styles/components/pages/Offer/_OfferV2.scss
+++ b/src/styles/components/pages/Offer/_OfferV2.scss
@@ -1,11 +1,13 @@
 .offer-page-v2 {
   .page-subtitle {
     @include caption();
+
     color: $grey-dark;
   }
 
   .content {
     margin-top: rem(24px);
+
     .offer-form {
       max-width: rem(486px);
 
@@ -18,5 +20,12 @@
   .debug {
     position: static;
     white-space: pre-wrap;
+  }
+
+  .nb-dates {
+    color: $primary;
+    display: inline-block;
+    font-weight: 700;
+    margin-right: 2rem;
   }
 }


### PR DESCRIPTION
Ajout du bouton de gestion des stocks,
Afin que celui-ci fonctionne, on utilise l'ancien store.

TODO:
- [x] Affichage de la modal des stocks 
- [ ] Tests sur la création manquant
- [x] Mapping des erreurs back/front

Il me semble que seul le champs `venue` nécessite d'etre mappé en `venueId`, voir https://github.com/pass-culture/pass-culture-api/blob/master/src/pcapi/validation/models/offer.py

note: 

- [x] Tests sur l'édition pour le readonly
Ce point à été déplacé dans une PR dédié : https://github.com/pass-culture/pass-culture-pro/pull/902