### PR TITLE
Mob user remove request data

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -29,18 +29,17 @@ export const App = props => {
 
     if (!currentUser) {
       setIsBusy(true)
-      getCurrentUser({
-        handleSuccess: () => {
+      getCurrentUser()
+        .then(() => {
           setIsBusy(false)
-        },
-        handleFail: () => {
+        })
+        .catch(() => {
           if (!isPublicRoute) {
             const fromUrl = encodeURIComponent(`${location.pathname}${location.search}`)
             history.push(`/connexion?de=${fromUrl}`)
           }
           setIsBusy(false)
-        },
-      })
+        })
     }
   }, [currentUser, currentPathname, getCurrentUser, history, location])
 

--- a/src/app/AppContainer.js
+++ b/src/app/AppContainer.js
@@ -1,34 +1,22 @@
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
-import { requestData } from 'redux-saga-data'
 
-import { selectCurrentUser, resolveCurrentUser } from 'store/selectors/data/usersSelectors'
 import { maintenanceSelector } from 'store/selectors/maintenanceSelector'
+import { getCurrentUser } from 'store/users/thunks'
 
 import { App } from './App'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     modalOpen: state.modal.isActive,
     isMaintenanceActivated: maintenanceSelector(state),
   }
 }
 
-export function mapDispatchToProps(dispatch) {
-  return {
-    getCurrentUser: ({ handleFail, handleSuccess }) => {
-      dispatch(
-        requestData({
-          apiPath: '/users/current',
-          resolve: resolveCurrentUser,
-          handleFail,
-          handleSuccess,
-        })
-      )
-    },
-  }
+export const mapDispatchToProps = {
+  getCurrentUser,
 }
 
 export default compose(withRouter, connect(mapStateToProps, mapDispatchToProps))(App)

--- a/src/app/__specs__/App.spec.jsx
+++ b/src/app/__specs__/App.spec.jsx
@@ -1,48 +1,43 @@
-import { mount, shallow } from 'enzyme/build'
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { App } from '../App'
-import RedirectToMaintenance from '../RedirectToMaintenance'
 
-const getCurrentUser = ({ handleSuccess }) => {
-  handleSuccess()
+const getCurrentUser = async () => Promise.resolve()
+
+const renderApp = async props => {
+  return await act(async () => {
+    await render(
+      <App {...props}>
+        <p>
+          {'Sub component'}
+        </p>
+      </App>
+    )
+  })
 }
 
 describe('src | App', () => {
-  it('should render App and children components when isMaintenanceActivated is false', () => {
+  it('should render App and children components when isMaintenanceActivated is false', async () => {
     // Given
     const props = { modalOpen: false, isMaintenanceActivated: false, getCurrentUser }
 
     // When
-    const wrapper = mount(
-      <App {...props}>
-        <p>
-          {'Sub component'}
-        </p>
-      </App>
-    )
+    await renderApp(props)
 
     // Then
-    const appNode = wrapper.find(App)
-    expect(appNode).toHaveLength(1)
-    expect(appNode.text()).toBe('Sub component')
+    expect(screen.getByText('Sub component')).toBeInTheDocument()
   })
 
-  it('should render a Redirect component when isMaintenanceActivated is true', () => {
+  it('should render a Redirect component when isMaintenanceActivated is true', async () => {
     // Given
     const props = { modalOpen: false, isMaintenanceActivated: true, getCurrentUser }
 
     // When
-    const wrapper = shallow(
-      <App {...props}>
-        <p>
-          {'Sub component'}
-        </p>
-      </App>
-    )
+    await renderApp(props)
 
     // Then
-    const redirectToMaintenanceElement = wrapper.find(RedirectToMaintenance)
-    expect(redirectToMaintenanceElement).toHaveLength(1)
+    expect(screen.queryByText('Sub component')).toBeNull()
   })
 })

--- a/src/app/__specs__/AppContainer.spec.js
+++ b/src/app/__specs__/AppContainer.spec.js
@@ -4,8 +4,8 @@ describe('src | AppContainer', () => {
   it('should map maintenance status to App', () => {
     // Given
     const state = {
-      data: {
-        users: [],
+      users: {
+        currentUser: null,
       },
       modal: { isActive: true },
       maintenance: { isActivated: true },
@@ -21,8 +21,8 @@ describe('src | AppContainer', () => {
   it('should map the modal status to App', () => {
     // Given
     const state = {
-      data: {
-        users: [],
+      users: {
+        currentUser: null,
       },
       modal: { isActive: false },
       maintenance: { isActivated: true },

--- a/src/components/layout/CsvTable/CsvTableContainer.js
+++ b/src/components/layout/CsvTable/CsvTableContainer.js
@@ -2,15 +2,13 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { compose } from 'redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import csvConverter from '../CsvTableButton/utils/csvConverter'
 
 import CsvTable from './CsvTable'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/layout/Header/HeaderContainer.js
+++ b/src/components/layout/Header/HeaderContainer.js
@@ -2,13 +2,11 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Header from './Header'
 
 export const mapStateToProps = state => {
   const { data } = state
-  const user = selectCurrentUser(state)
+  const user = state.users.currentUser
   const { publicName: name } = user
   const { offerers } = data
 

--- a/src/components/layout/Main/mapStateToProps.js
+++ b/src/components/layout/Main/mapStateToProps.js
@@ -1,8 +1,6 @@
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/matomo/MatomoContainer.js
+++ b/src/components/matomo/MatomoContainer.js
@@ -2,12 +2,10 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Matomo from './Matomo'
 
 export const mapStateToProps = state => {
-  const user = selectCurrentUser(state)
+  const user = state.users.currentUser
   let userId = user ? user.id : 'ANONYMOUS'
 
   return {

--- a/src/components/matomo/__specs__/Matomo.spec.jsx
+++ b/src/components/matomo/__specs__/Matomo.spec.jsx
@@ -21,6 +21,11 @@ describe('src | components | Matomo', () => {
     }
     window._paq = fakeMatomo
     store = getStubStore({
+      users: (
+        state = {
+          currentUser: null,
+        }
+      ) => state,
       data: (state = {}) => state,
     })
   })
@@ -96,13 +101,11 @@ describe('src | components | Matomo', () => {
     it('should dispatch setUserId with current user id', () => {
       // given
       const store = getStubStore({
-        data: (
+        users: (
           state = {
-            users: [
-              {
-                id: 'TY',
-              },
-            ],
+            currentUser: {
+              id: 'TY',
+            },
           }
         ) => state,
       })

--- a/src/components/matomo/__specs__/MatomoContainer.spec.js
+++ b/src/components/matomo/__specs__/MatomoContainer.spec.js
@@ -5,12 +5,8 @@ describe('src | components | matomo | MatomoContainer', () => {
     it('should return an object of props when user is logged in', () => {
       // given
       const state = {
-        data: {
-          users: [
-            {
-              id: 'TY7',
-            },
-          ],
+        users: {
+          currentUser: { id: 'TY7' },
         },
       }
 
@@ -24,8 +20,8 @@ describe('src | components | matomo | MatomoContainer', () => {
     it('should return an object of props when user is logged out', () => {
       // given
       const state = {
-        data: {
-          users: [],
+        users: {
+          currentUser: null,
         },
       }
 

--- a/src/components/pages/Bookings/BookingsRecapContainer.js
+++ b/src/components/pages/Bookings/BookingsRecapContainer.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import BookingsRecap from './BookingsRecap'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Desk/DeskContainer.js
+++ b/src/components/pages/Desk/DeskContainer.js
@@ -2,14 +2,13 @@ import { connect } from 'react-redux'
 import { compose } from 'redux'
 
 import { withTracking } from 'components/hocs'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { fetchFromApiWithCredentials } from 'utils/fetch'
 
 import Desk from './Desk'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Desk/__specs__/Desk.spec.jsx
+++ b/src/components/pages/Desk/__specs__/Desk.spec.jsx
@@ -11,6 +11,11 @@ import Desk from '../Desk'
 
 const renderDesk = props => {
   const stubbedStore = getStubStore({
+    users: (
+      state = {
+        currentUser: { publicName: 'USER' },
+      }
+    ) => state,
     data: (
       state = {
         users: [{ publicName: 'USER' }],

--- a/src/components/pages/Home/HomeContainer.js
+++ b/src/components/pages/Home/HomeContainer.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Home from './Home'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/LostPassword/LostPasswordContainer.js
+++ b/src/components/pages/LostPassword/LostPasswordContainer.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { requestData } from 'redux-saga-data'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { searchSelector } from 'store/selectors/search'
 import { getReCaptchaToken } from 'utils/recaptcha'
 
@@ -18,7 +17,7 @@ export const mapStateToProps = (state, ownProps) => {
   const { change, envoye, token } = searchSelector(state, search)
   return {
     change,
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     errors: userErrors,
     envoye,
     token,

--- a/src/components/pages/LostPassword/__specs__/LostPasswordContainer.spec.js
+++ b/src/components/pages/LostPassword/__specs__/LostPasswordContainer.spec.js
@@ -11,9 +11,7 @@ describe('src | components | pages | LostPassword', () => {
       },
     }
     state = {
-      data: {
-        users: [],
-      },
+      users: { currentUser: null },
       errors: {
         user: null,
       },
@@ -27,7 +25,7 @@ describe('src | components | pages | LostPassword', () => {
 
       // then
       expect(result).toStrictEqual({
-        currentUser: undefined,
+        currentUser: null,
         change: '1',
         envoye: undefined,
         errors: [],

--- a/src/components/pages/Mediation/MediationContainer.js
+++ b/src/components/pages/Mediation/MediationContainer.js
@@ -7,10 +7,8 @@ import { loadOffer } from 'store/offers/thunks'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectMediationById } from 'store/selectors/data/mediationsSelectors'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { selectVenueById } from 'store/selectors/data/venuesSelectors'
 import { mediationNormalizer, offererNormalizer } from 'utils/normalizers'
-
 
 import Mediation from './Mediation'
 
@@ -23,7 +21,7 @@ export const mapStateToProps = (state, ownProps) => {
   const offer = selectOfferById(state, offerId)
   const venue = selectVenueById(state, get(offer, 'venueId'))
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     offer,
     offerer: selectOffererById(state, venue.managingOffererId),
     venue,

--- a/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
+++ b/src/components/pages/Mediation/__specs__/MediationContainer.spec.js
@@ -202,7 +202,7 @@ describe('src | components | pages | MediationContainer', () => {
 
       // then
       expect(result).toStrictEqual({
-        currentUser: undefined,
+        currentUser: null,
         mediation: overrideState.data.mediations[0],
         offer: overrideState.offers.list[0],
         offerer: overrideState.data.offerers[0],

--- a/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useState, Fragment } from 'react'
 
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Spinner from 'components/layout/Spinner'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import OfferCreation from './OfferForm/OfferCreation'
 import OfferEditionContainer from './OfferForm/OfferEditionContainer'

--- a/src/components/pages/Offer/Offer/OfferDetails/OfferForm/OfferCreation.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferForm/OfferCreation.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import OfferForm from './OfferForm'
 

--- a/src/components/pages/Offer/Offer/OfferDetails/OfferForm/OfferEdition.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferForm/OfferEdition.jsx
@@ -5,7 +5,7 @@ import {
   isFieldReadOnlyForSynchronizedOffer,
   isSynchronizedOffer,
 } from 'components/pages/Offer/domain/localProvider'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import { computeOffersUrl } from '../../../utils/computeOffersUrl'
 

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreationForAdmin.spec.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router'
 
 import NotificationV2Container from 'components/layout/NotificationV2/NotificationV2Container'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
 import OfferLayoutContainer from '../../OfferLayoutContainer'

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router'
 
 import NotificationV2Container from 'components/layout/NotificationV2/NotificationV2Container'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
 import OfferLayoutContainer from '../../OfferLayoutContainer'
@@ -53,7 +53,9 @@ describe('offerDetails - Creation - pro user', () => {
   let venues
 
   beforeEach(() => {
-    store = configureTestStore({ data: { users: [{ publicName: 'François', isAdmin: false }] } })
+    store = configureTestStore({
+      users: { currentUser: { publicName: 'François', isAdmin: false } },
+    })
     props = {
       setShowThumbnailForm: jest.fn(),
     }

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
@@ -7,7 +7,7 @@ import { MemoryRouter, Route } from 'react-router'
 
 import NotificationV2Container from 'components/layout/NotificationV2/NotificationV2Container'
 import { getProviderInfo } from 'components/pages/Offer/LocalProviderInformation/getProviderInfo'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
 import * as computeUrl from '../../../utils/computeOffersUrl'
@@ -56,7 +56,7 @@ describe('offerDetails - Edition', () => {
   let editedOfferVenue
 
   beforeEach(() => {
-    store = configureTestStore({ data: { users: [{ publicName: 'François', isAdmin: false }] } })
+    store = configureTestStore({ users: { currentUser: { publicName: 'François', isAdmin: false } } })
     types = [
       {
         conditionalFields: [],

--- a/src/components/pages/Offer/Offer/OfferLayout.jsx
+++ b/src/components/pages/Offer/Offer/OfferLayout.jsx
@@ -4,7 +4,7 @@ import { Switch, Route } from 'react-router-dom'
 import Titles from 'components/layout/Titles/Titles'
 import OfferDetailsContainer from 'components/pages/Offer/Offer/OfferDetails/OfferDetailsContainer'
 import StocksContainer from 'components/pages/Offer/Offer/Stocks/StocksContainer'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import Breadcrumb, { STEP_ID_DETAILS, STEP_ID_STOCKS } from './Breadcrumb'
 import OfferPreviewLink from './OfferPreviewLink/OfferPreviewLink'

--- a/src/components/pages/Offer/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
+++ b/src/components/pages/Offer/Offer/Stocks/DeleteStockDialog/DeleteStockDialog.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useCallback, useRef } from 'react'
 
 import { DialogBox } from 'components/layout/DialogBox/DialogBox'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import { ReactComponent as DeletionIcon } from './assets/deletion.svg'
 

--- a/src/components/pages/Offer/Offer/Stocks/Stocks.jsx
+++ b/src/components/pages/Offer/Offer/Stocks/Stocks.jsx
@@ -6,7 +6,7 @@ import { v4 as generateRandomUuid } from 'uuid'
 
 import Icon from 'components/layout/Icon'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { getDepartmentTimezone } from 'utils/timezone'
 
 import { EVENT_CANCELLATION_INFORMATION, THING_CANCELLATION_INFORMATION } from './_constants'

--- a/src/components/pages/Offer/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/src/components/pages/Offer/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux'
 import { MemoryRouter, Route } from 'react-router'
 
 import NotificationV2Container from 'components/layout/NotificationV2/NotificationV2Container'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 import { queryByTextTrimHtml } from 'utils/testHelpers'
 

--- a/src/components/pages/Offer/Offer/Thumbnail/ImportFromURL/ImportFromURL.jsx
+++ b/src/components/pages/Offer/Offer/Thumbnail/ImportFromURL/ImportFromURL.jsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react'
 
 import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import { ReactComponent as ThumbnailSampleIcon } from 'components/pages/Offer/Offer/Thumbnail/assets/thumbnail-sample.svg'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 const ImportFromURL = ({ setStep, setURL }) => {
   const [isButtonDisabled, setIsButtonDisabled] = useState(true)

--- a/src/components/pages/Offer/Offer/Thumbnail/__specs__/Thumbnail.spec.jsx
+++ b/src/components/pages/Offer/Offer/Thumbnail/__specs__/Thumbnail.spec.jsx
@@ -15,7 +15,7 @@ import {
   MIN_IMAGE_WIDTH,
 } from 'components/pages/Offer/Offer/Thumbnail/_constants'
 import ThumbnailDialog from 'components/pages/Offer/Offer/Thumbnail/ThumbnailDialog'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import CanvasTools from 'utils/canvas.js'
 
 jest.mock('utils/canvas.js')

--- a/src/components/pages/Offer/Offer/__specs__/OfferLayout.spec.jsx
+++ b/src/components/pages/Offer/Offer/__specs__/OfferLayout.spec.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
 import OfferLayout from '../OfferLayout'

--- a/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
+++ b/src/components/pages/Offer/OfferCreation/OfferCreationContainer.js
@@ -14,7 +14,6 @@ import { selectProductById } from 'store/selectors/data/productsSelectors'
 import { selectProviders } from 'store/selectors/data/providersSelectors'
 import { selectStocksByOfferId } from 'store/selectors/data/stocksSelectors'
 import { selectTypesByIsVenueVirtual } from 'store/selectors/data/typesSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import {
   selectVenueById,
   selectVenuesByOffererIdAndOfferType,
@@ -91,7 +90,7 @@ export const mapStateToProps = (state, ownProps) => {
   const offerTypeError = get(state, 'errors.offer.type')
 
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     formInitialValues,
     formOffererId,
     formVenueId,

--- a/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
+++ b/src/components/pages/Offer/OfferCreation/__specs__/OfferCreation.spec.jsx
@@ -30,6 +30,11 @@ const buildStore = (store = {}) => {
     publicName: 'USER',
   }
   return getStubStore({
+    users: (
+      state = {
+        currentUser,
+      }
+    ) => state,
     data: (
       state = {
         offerers: [],

--- a/src/components/pages/Offer/OfferCreation/__specs__/OfferCreationContainer.spec.jsx
+++ b/src/components/pages/Offer/OfferCreation/__specs__/OfferCreationContainer.spec.jsx
@@ -29,7 +29,7 @@ describe('src | OfferCreationContainer', () => {
 
       // then
       expect(result).toStrictEqual({
-        currentUser: state.data.users[0],
+        currentUser: state.users.currentUser,
         formInitialValues: {
           ageMax: undefined,
           ageMin: undefined,

--- a/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
+++ b/src/components/pages/Offer/OfferEdition/OfferEditionContainer.js
@@ -13,7 +13,6 @@ import { selectProductById } from 'store/selectors/data/productsSelectors'
 import { selectProviders } from 'store/selectors/data/providersSelectors'
 import { selectStocksByOfferId } from 'store/selectors/data/stocksSelectors'
 import { selectTypesByIsVenueVirtual } from 'store/selectors/data/typesSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import {
   selectVenueById,
   selectVenuesByOffererIdAndOfferType,
@@ -88,7 +87,7 @@ export const mapStateToProps = (state, ownProps) => {
   const offerTypeError = get(state, 'errors.offer.type')
 
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     formInitialValues,
     formOffererId,
     formVenueId,

--- a/src/components/pages/Offer/OfferEdition/__specs__/OfferEditionContainer.spec.jsx
+++ b/src/components/pages/Offer/OfferEdition/__specs__/OfferEditionContainer.spec.jsx
@@ -29,7 +29,7 @@ describe('components | OfferEdition | OfferEditionContainer', () => {
 
       // then
       expect(result).toStrictEqual({
-        currentUser: state.data.users[0],
+        currentUser: state.users.currentUser,
         formInitialValues: {
           ageMax: undefined,
           ageMin: undefined,

--- a/src/components/pages/Offerer/OffererCreation/OffererCreationContainer.js
+++ b/src/components/pages/Offerer/OffererCreation/OffererCreationContainer.js
@@ -5,13 +5,12 @@ import { requestData } from 'redux-saga-data'
 
 import withTracking from 'components/hocs/withTracking'
 import { closeNotification, showNotificationV1 } from 'store/reducers/notificationReducer'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 
 import OffererCreation from './OffererCreation'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Offerer/OffererDetails/OffererDetailsContainer.js
+++ b/src/components/pages/Offerer/OffererDetails/OffererDetailsContainer.js
@@ -5,7 +5,6 @@ import { requestData } from 'redux-saga-data'
 import withTracking from 'components/hocs/withTracking'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
 import { selectUserOffererByOffererIdAndUserIdAndRightsType } from 'store/selectors/data/userOfferersSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { selectPhysicalVenuesByOffererId } from 'store/selectors/data/venuesSelectors'
 import { offererNormalizer } from 'utils/normalizers'
 
@@ -17,7 +16,7 @@ export const mapStateToProps = (state, ownProps) => {
   const {
     params: { offererId },
   } = match
-  const currentUser = selectCurrentUser(state)
+  const currentUser = state.users.currentUser
   return {
     currentUser,
     offerer: makeOffererComponentValueObject(

--- a/src/components/pages/Offerer/OffererDetails/__specs__/OffererDetailsContainer.spec.js
+++ b/src/components/pages/Offerer/OffererDetails/__specs__/OffererDetailsContainer.spec.js
@@ -12,12 +12,12 @@ describe('src | components | pages | Offerer | OffererDetails | OffererDetailsCo
     it('should return an object of props', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            id: 'TY56er',
+          },
+        },
         data: {
-          users: [
-            {
-              id: 'TY56er',
-            },
-          ],
           userOfferers: [
             {
               id: 'AEKQ',
@@ -78,12 +78,12 @@ describe('src | components | pages | Offerer | OffererDetails | OffererDetailsCo
     it('should return offerer id from url', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            id: 'TY56er',
+          },
+        },
         data: {
-          users: [
-            {
-              id: 'TY56er',
-            },
-          ],
           userOfferers: [
             {
               id: 'AEKQ',

--- a/src/components/pages/Offerers/OfferersContainer.jsx
+++ b/src/components/pages/Offerers/OfferersContainer.jsx
@@ -7,7 +7,6 @@ import { OFFERERS_API_PATH } from 'config/apiPaths'
 import { closeNotification, showNotificationV1 } from 'store/reducers/notificationReducer'
 import { isAPISireneAvailable } from 'store/selectors/data/featuresSelectors'
 import { selectOfferers } from 'store/selectors/data/offerersSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { offererNormalizer } from 'utils/normalizers'
 import { stringify } from 'utils/query-string'
 
@@ -29,7 +28,7 @@ export const createApiPath = searchKeyWords => {
 
 export const mapStateToProps = state => {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     isOffererCreationAvailable: isAPISireneAvailable(state),
     notification: state.notification,
     offerers: selectOfferers(state),

--- a/src/components/pages/Offerers/__specs__/OfferersContainer.spec.jsx
+++ b/src/components/pages/Offerers/__specs__/OfferersContainer.spec.jsx
@@ -1,4 +1,5 @@
-import state from '../../../utils/mocks/state'
+import state from 'components/utils/mocks/state'
+
 import { mapStateToProps, mapDispatchToProps, createApiPath } from '../OfferersContainer'
 
 describe('src | components | pages | Offerers | OfferersContainer', () => {
@@ -12,7 +13,7 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
 
       // then
       const expected = {
-        currentUser: state.data.users[0],
+        currentUser: state.users.currentUser,
         isOffererCreationAvailable: false,
         notification: null,
         offerers: [
@@ -64,6 +65,9 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
         // given
         const props = {}
         const state = {
+          users: {
+            currentUser: null,
+          },
           data: {
             features: [
               {
@@ -85,6 +89,9 @@ describe('src | components | pages | Offerers | OfferersContainer', () => {
         // given
         const props = {}
         const state = {
+          users: {
+            currentUser: null,
+          },
           data: {
             features: [
               {

--- a/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
+++ b/src/components/pages/Offers/ActionsBar/ActionsBar.jsx
@@ -2,8 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 
 import Icon from 'components/layout/Icon'
-
-import { updateOffersActiveStatus } from '../../../../repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 const computeActivationSuccessMessage = nbSelectedOffers => {
   const successMessage =
@@ -47,7 +46,7 @@ const ActionsBar = props => {
       }
       const body = areAllOffersSelected ? bodyAllActiveStatus : bodySomeActiveStatus
 
-      updateOffersActiveStatus(areAllOffersSelected, body).then(() => {
+      pcapi.updateOffersActiveStatus(areAllOffersSelected, body).then(() => {
         refreshOffers({ shouldTriggerSpinner: false })
         showSuccessNotification(
           isActivating

--- a/src/components/pages/Offers/ActionsBar/__specs__/ActionsBar.spec.jsx
+++ b/src/components/pages/Offers/ActionsBar/__specs__/ActionsBar.spec.jsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
-import { updateOffersActiveStatus } from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 
 import ActionsBar from '../ActionsBar'
 
@@ -79,7 +79,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
 
       // then
       await waitFor(() => {
-        expect(updateOffersActiveStatus).toHaveBeenLastCalledWith(false, expectedBody)
+        expect(pcapi.updateOffersActiveStatus).toHaveBeenLastCalledWith(false, expectedBody)
         expect(props.clearSelectedOfferIds).toHaveBeenCalledTimes(1)
         expect(props.refreshOffers).toHaveBeenCalledWith({ shouldTriggerSpinner: false })
         expect(props.trackActivateOffers).toHaveBeenCalledWith(['testId1', 'testId2'])
@@ -128,7 +128,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
 
       // then
       await waitFor(() => {
-        expect(updateOffersActiveStatus).toHaveBeenLastCalledWith(false, expectedBody)
+        expect(pcapi.updateOffersActiveStatus).toHaveBeenLastCalledWith(false, expectedBody)
         expect(props.clearSelectedOfferIds).toHaveBeenCalledTimes(1)
         expect(props.refreshOffers).toHaveBeenCalledWith({ shouldTriggerSpinner: false })
         expect(props.trackDeactivateOffers).toHaveBeenCalledWith(['testId1', 'testId2'])
@@ -194,7 +194,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
 
       // then
       await waitFor(() => {
-        expect(updateOffersActiveStatus).toHaveBeenLastCalledWith(true, expectedBody)
+        expect(pcapi.updateOffersActiveStatus).toHaveBeenLastCalledWith(true, expectedBody)
         expect(props.clearSelectedOfferIds).toHaveBeenCalledTimes(1)
         expect(props.refreshOffers).toHaveBeenCalledWith({ shouldTriggerSpinner: false })
       })
@@ -218,7 +218,7 @@ describe('src | components | pages | Offers | ActionsBar', () => {
 
       // then
       await waitFor(() => {
-        expect(updateOffersActiveStatus).toHaveBeenLastCalledWith(true, expectedBody)
+        expect(pcapi.updateOffersActiveStatus).toHaveBeenLastCalledWith(true, expectedBody)
         expect(props.clearSelectedOfferIds).toHaveBeenCalledTimes(1)
         expect(props.refreshOffers).toHaveBeenCalledWith({ shouldTriggerSpinner: false })
       })

--- a/src/components/pages/Offers/Offers.jsx
+++ b/src/components/pages/Offers/Offers.jsx
@@ -11,7 +11,7 @@ import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Spinner from 'components/layout/Spinner'
 import Titles from 'components/layout/Titles/Titles'
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { fetchAllVenuesByProUser, formatAndOrderVenues } from 'repository/venuesService'
 import { mapApiToBrowser, mapBrowserToApi, translateQueryParamsToApiParams } from 'utils/translate'
 

--- a/src/components/pages/Offers/OffersContainer.js
+++ b/src/components/pages/Offers/OffersContainer.js
@@ -10,14 +10,13 @@ import {
   setAllVenueOffersInactivate,
 } from 'store/offers/thunks'
 import { closeNotification, showNotificationV1 } from 'store/reducers/notificationReducer'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { fetchFromApiWithCredentials } from 'utils/fetch'
 
 import Offers from './Offers'
 
 export const mapStateToProps = state => {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     getOfferer: fetchOffererById,
     notification: state.notification,
     offers: selectOffers(state),

--- a/src/components/pages/Offers/__specs__/Offers.spec.jsx
+++ b/src/components/pages/Offers/__specs__/Offers.spec.jsx
@@ -6,7 +6,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { fetchAllVenuesByProUser } from 'repository/venuesService'
 import { configureTestStore } from 'store/testUtils'
 import { queryByTextTrimHtml, renderWithStyles } from 'utils/testHelpers'
@@ -119,8 +119,8 @@ describe('src | components | pages | Offers | Offers', () => {
     parse = jest.fn().mockReturnValue({})
     currentUser = { id: 'EY', isAdmin: false, name: 'Current User', publicName: 'USER' }
     store = configureTestStore({
+      users: { currentUser },
       data: {
-        users: [currentUser],
         venues: [{ id: 'JI', name: 'Venue' }],
       },
     })

--- a/src/components/pages/Profil/ProfilContainer.jsx
+++ b/src/components/pages/Profil/ProfilContainer.jsx
@@ -1,11 +1,9 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Profil from './Profil'
 
 export const mapStateToProps = state => ({
-  currentUser: selectCurrentUser(state),
+  currentUser: state.users.currentUser,
 })
 
 export default connect(mapStateToProps)(Profil)

--- a/src/components/pages/Profil/tests/Profil.spec.jsx
+++ b/src/components/pages/Profil/tests/Profil.spec.jsx
@@ -32,8 +32,8 @@ describe('src | components | pages | Profil', () => {
       dispatch,
     }
     store = configureStore({
+      users: { currentUser: { id: 'CMOI', publicName: 'user' } },
       data: {
-        users: [{ id: 'CMOI', publicName: 'user' }],
         offerers: [],
       },
     }).store

--- a/src/components/pages/Profil/tests/ProfilContainer.spec.jsx
+++ b/src/components/pages/Profil/tests/ProfilContainer.spec.jsx
@@ -6,7 +6,7 @@ describe('src | components | pages | Profil | ProfilContainer', () => {
       // given
       const id = '1'
       const state = {
-        data: { users: [{ id }] },
+        users: { currentUser: { id } },
       }
 
       // when

--- a/src/components/pages/Reimbursements/ReimbursementsContainer.js
+++ b/src/components/pages/Reimbursements/ReimbursementsContainer.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Reimbursements from './Reimbursements'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Signin/SigninContainer.js
+++ b/src/components/pages/Signin/SigninContainer.js
@@ -4,13 +4,12 @@ import { compose } from 'redux'
 import { requestData } from 'redux-saga-data'
 
 import { isAPISireneAvailable } from 'store/selectors/data/featuresSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 
 import Signin from './Signin'
 
 export const mapStateToProps = state => {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
     isAccountCreationAvailable: isAPISireneAvailable(state),
   }
 }

--- a/src/components/pages/Signin/__specs__/SigninContainer.spec.js
+++ b/src/components/pages/Signin/__specs__/SigninContainer.spec.js
@@ -5,6 +5,9 @@ describe('pages | Signin | SigninContainer', () => {
     it('should mark account creation as disabled', () => {
       // given
       const state = {
+        users: {
+          currentUser: null,
+        },
         data: {
           features: [
             {
@@ -27,6 +30,9 @@ describe('pages | Signin | SigninContainer', () => {
     it('should mark account creation as disabled', () => {
       // given
       const state = {
+        users: {
+          currentUser: null,
+        },
         data: {
           features: [
             {

--- a/src/components/pages/Signup/SignupContainer.js
+++ b/src/components/pages/Signup/SignupContainer.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Signup from './Signup'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Signup/SignupForm/SignupFormContainer.js
+++ b/src/components/pages/Signup/SignupForm/SignupFormContainer.js
@@ -7,14 +7,13 @@ import { requestData } from 'redux-saga-data'
 
 import { removeErrors } from 'store/reducers/errors'
 import { closeNotification, showNotificationV1 } from 'store/reducers/notificationReducer'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 
 import SignupForm from './SignupForm'
 
 const STATE_ERROR_NAME = 'user'
 
 export const mapStateToProps = state => ({
-  currentUser: selectCurrentUser(state),
+  currentUser: state.users.currentUser,
   errors: get(state, `errors["${STATE_ERROR_NAME}"]`),
 })
 

--- a/src/components/pages/Signup/SignupValidation/SignupValidationContainer.js
+++ b/src/components/pages/Signup/SignupValidation/SignupValidationContainer.js
@@ -2,13 +2,11 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { compose } from 'redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import SignupValidation from './SignupValidation'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Styleguide/StyleguideContainer.js
+++ b/src/components/pages/Styleguide/StyleguideContainer.js
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
-
 import Styleguide from './Styleguide'
 
 export function mapStateToProps(state) {
   return {
-    currentUser: selectCurrentUser(state),
+    currentUser: state.users.currentUser,
   }
 }
 

--- a/src/components/pages/Venue/VenueCreation/VenueCreationContainer.js
+++ b/src/components/pages/Venue/VenueCreation/VenueCreationContainer.js
@@ -7,7 +7,6 @@ import { CREATION } from 'components/hocs/withFrenchQueryRouter'
 import withTracking from 'components/hocs/withTracking'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { selectVenueLabels } from 'store/selectors/data/venueLabelsSelectors'
 import { selectVenueTypes } from 'store/selectors/data/venueTypesSelectors'
 
@@ -26,7 +25,7 @@ export const mapStateToProps = (state, ownProps) => {
     },
   } = ownProps
 
-  const currentUser = selectCurrentUser(state)
+  const currentUser = state.users.currentUser
   return {
     currentUser: currentUser,
     venueTypes: selectVenueTypes(state).map(type => new VenueType(type)),

--- a/src/components/pages/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
+++ b/src/components/pages/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
@@ -165,6 +165,13 @@ describe('src | components | pages | Venue', () => {
         }
 
         const store = getStubStore({
+          users: (
+            state = {
+              currentUser: {
+                name: 'test name',
+              },
+            }
+          ) => state,
           data: (
             state = {
               offerers: [],

--- a/src/components/pages/Venue/VenueCreation/__specs__/VenueCreationContainer.spec.jsx
+++ b/src/components/pages/Venue/VenueCreation/__specs__/VenueCreationContainer.spec.jsx
@@ -39,11 +39,11 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
       // given
       const currentUser = { id: 1, email: 'john.doe@email.com' }
       const state = {
+        users: { currentUser },
         data: {
           offerers: [{ id: 1 }],
           userOfferers: [{ offererId: 1, rights: 'admin', userId: 1 }],
           venues: [],
-          users: [currentUser],
         },
       }
 
@@ -66,6 +66,11 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
     it('should map venue types for the component', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            email: 'john.doe@example.net',
+          },
+        },
         data: {
           offerers: [],
           userOfferers: [],
@@ -73,11 +78,6 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
           'venue-types': [
             { id: 'AE', label: 'Patrimoine et tourisme' },
             { id: 'AF', label: 'Autre' },
-          ],
-          users: [
-            {
-              email: 'john.doe@example.net',
-            },
           ],
         },
       }
@@ -100,6 +100,11 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
     it('should map venue labels for the component', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            email: 'john.doe@example.net',
+          },
+        },
         data: {
           offerers: [],
           userOfferers: [],
@@ -107,11 +112,6 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
           'venue-labels': [
             { id: 'AE', label: "CAC - Centre d'art contemporain d'intérêt national" },
             { id: 'AF', label: "Ville et Pays d'art et d'histoire" },
-          ],
-          users: [
-            {
-              email: 'john.doe@example.net',
-            },
           ],
         },
       }

--- a/src/components/pages/Venue/VenueEdition/VenueEditionContainer.js
+++ b/src/components/pages/Venue/VenueEdition/VenueEditionContainer.js
@@ -6,7 +6,6 @@ import withQueryRouter from 'with-query-router'
 import withTracking from 'components/hocs/withTracking'
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
 import { selectOffererById } from 'store/selectors/data/offerersSelectors'
-import { selectCurrentUser } from 'store/selectors/data/usersSelectors'
 import { selectVenueLabels } from 'store/selectors/data/venueLabelsSelectors'
 import { selectVenueById } from 'store/selectors/data/venuesSelectors'
 import { selectVenueTypes } from 'store/selectors/data/venueTypesSelectors'
@@ -26,7 +25,7 @@ export const mapStateToProps = (
     },
   }
 ) => ({
-  currentUser: selectCurrentUser(state),
+  currentUser: state.users.currentUser,
   venueTypes: selectVenueTypes(state).map(type => new VenueType(type)),
   venueLabels: selectVenueLabels(state).map(label => new VenueLabel(label)),
   venue: selectVenueById(state, venueId),

--- a/src/components/pages/Venue/VenueEdition/__specs__/VenueEdition.spec.jsx
+++ b/src/components/pages/Venue/VenueEdition/__specs__/VenueEdition.spec.jsx
@@ -117,6 +117,14 @@ describe('src | components | pages | VenueEdition', () => {
         }
 
         const store = getStubStore({
+          users: (
+            state = {
+              currentUser: {
+                id: 'test_id',
+                name: 'John Do',
+              },
+            }
+          ) => state,
           data: (
             state = {
               offerers: [],
@@ -192,6 +200,14 @@ describe('src | components | pages | VenueEdition', () => {
           }
 
           const store = getStubStore({
+            users: (
+              state = {
+                currentUser: {
+                  id: 'test_id',
+                  name: 'John Do',
+                },
+              }
+            ) => state,
             data: (
               state = {
                 offerers: [],

--- a/src/components/pages/Venue/VenueEdition/__specs__/VenueEditionContainer.spec.jsx
+++ b/src/components/pages/Venue/VenueEdition/__specs__/VenueEditionContainer.spec.jsx
@@ -35,6 +35,7 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
     it('should return an object with props', () => {
       // given
       const state = {
+        users: { currentUser: null },
         data: {
           offerers: [{ id: 1 }],
           userOfferers: [{ offererId: 1, rights: 'admin', userId: 1 }],
@@ -44,7 +45,6 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
               managingOffererId: 'M4',
             },
           ],
-          users: [],
         },
       }
 
@@ -53,7 +53,7 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
 
       // then
       expect(result).toStrictEqual({
-        currentUser: undefined,
+        currentUser: null,
         offerer: { id: 1 },
         venue: {
           id: 'WQ',
@@ -67,6 +67,11 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
     it('should map venue types for the component', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            email: 'john.doe@example.net',
+          },
+        },
         data: {
           offerers: [],
           userOfferers: [],
@@ -74,11 +79,6 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
           'venue-types': [
             { id: 'AE', label: 'Patrimoine et tourisme' },
             { id: 'AF', label: 'Autre' },
-          ],
-          users: [
-            {
-              email: 'john.doe@example.net',
-            },
           ],
         },
       }
@@ -100,6 +100,11 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
     it('should map venue labels for the component', () => {
       // given
       const state = {
+        users: {
+          currentUser: {
+            email: 'john.doe@example.net',
+          },
+        },
         data: {
           offerers: [],
           userOfferers: [],
@@ -107,11 +112,6 @@ describe('src | components | pages | VenueContainer | mapStateToProps', () => {
           'venue-labels': [
             { id: 'AE', label: "CAC - Centre d'art contemporain d'intérêt national" },
             { id: 'AF', label: "Ville et Pays d'art et d'histoire" },
-          ],
-          users: [
-            {
-              email: 'john.doe@example.net',
-            },
           ],
         },
       }

--- a/src/components/utils/mocks/state.js
+++ b/src/components/utils/mocks/state.js
@@ -735,24 +735,6 @@ const state = {
         lastProviderId: 123,
       },
     ],
-    users: [
-      {
-        id: 'FE',
-        canBookFeeOffers: false,
-        dateCreated: '2019-03-07T10:39:23.560374Z',
-        dateOfBirth: '2001-01-01T00:00:00Z',
-        departementCode: '93',
-        email: 'pctest.admin93.0@example.com',
-        firstName: 'PC Test Admin',
-        isAdmin: true,
-        lastName: '93 0',
-        modelName: 'User',
-        phoneNumber: '0612345678',
-        postalCode: '93100',
-        publicName: 'PC Test Admin 93 0',
-        thumbCount: 0,
-      },
-    ],
     userOfferers: [
       {
         offererId: 'FE',
@@ -868,6 +850,24 @@ const state = {
   },
   notification: null,
   tracker: {},
+  users: {
+    currentUser: {
+      id: 'FE',
+      canBookFeeOffers: false,
+      dateCreated: '2019-03-07T10:39:23.560374Z',
+      dateOfBirth: '2001-01-01T00:00:00Z',
+      departementCode: '93',
+      email: 'pctest.admin93.0@example.com',
+      firstName: 'PC Test Admin',
+      isAdmin: true,
+      lastName: '93 0',
+      modelName: 'User',
+      phoneNumber: '0612345678',
+      postalCode: '93100',
+      publicName: 'PC Test Admin 93 0',
+      thumbCount: 0,
+    },
+  },
   offers: {
     list: [
       {

--- a/src/repository/pcapi/__specs__/pcapi.spec.js
+++ b/src/repository/pcapi/__specs__/pcapi.spec.js
@@ -1,14 +1,7 @@
 import { DEFAULT_SEARCH_FILTERS } from 'components/pages/Offers/_constants'
 import { client } from 'repository/pcapi/pcapiClient'
 
-import {
-  createStock,
-  deleteStock,
-  getURLErrors,
-  loadFilteredOffers,
-  updateOffersActiveStatus,
-  updateStock,
-} from '../pcapi'
+import pcapi from '../pcapi'
 
 jest.mock('repository/pcapi/pcapiClient', () => ({
   client: {
@@ -59,7 +52,7 @@ describe('pcapi', () => {
 
     it('should return api response', async () => {
       // When
-      const response = await loadFilteredOffers({})
+      const response = await pcapi.loadFilteredOffers({})
 
       // Then
       expect(response).toBe(returnedResponse)
@@ -70,7 +63,7 @@ describe('pcapi', () => {
       const filters = {}
 
       // When
-      await loadFilteredOffers(filters)
+      await pcapi.loadFilteredOffers(filters)
 
       // Then
       expect(client.get).toHaveBeenCalledWith('/offers?page=1')
@@ -86,7 +79,7 @@ describe('pcapi', () => {
       }
 
       // When
-      await loadFilteredOffers(filters)
+      await pcapi.loadFilteredOffers(filters)
 
       // Then
       expect(client.get).toHaveBeenCalledWith('/offers?page=1')
@@ -103,7 +96,7 @@ describe('pcapi', () => {
       }
 
       // When
-      await loadFilteredOffers(filters)
+      await pcapi.loadFilteredOffers(filters)
 
       // Then
       expect(client.get).toHaveBeenCalledWith(
@@ -121,7 +114,7 @@ describe('pcapi', () => {
         }
 
         // when
-        await updateOffersActiveStatus(true, body)
+        await pcapi.updateOffersActiveStatus(true, body)
 
         // then
         expect(client.patch).toHaveBeenCalledWith('/offers/all-active-status', {
@@ -143,7 +136,7 @@ describe('pcapi', () => {
         }
 
         // when
-        await updateOffersActiveStatus(true, body)
+        await pcapi.updateOffersActiveStatus(true, body)
 
         // then
         expect(client.patch).toHaveBeenCalledWith('/offers/all-active-status', {
@@ -167,7 +160,7 @@ describe('pcapi', () => {
         }
 
         // when
-        await updateOffersActiveStatus(false, body)
+        await pcapi.updateOffersActiveStatus(false, body)
 
         // then
         expect(client.patch).toHaveBeenCalledWith('/offers/active-status', {
@@ -181,7 +174,7 @@ describe('pcapi', () => {
   describe('deleteStock', () => {
     it('should delete stock given its id', () => {
       // When
-      deleteStock('2E')
+      pcapi.deleteStock('2E')
 
       // Then
       expect(client.delete).toHaveBeenCalledWith('/stocks/2E')
@@ -191,7 +184,7 @@ describe('pcapi', () => {
   describe('updateStock', () => {
     it('should update stock given its id and changes', () => {
       // When
-      updateStock({
+      pcapi.updateStock({
         beginningDatetime: '2020-12-26T23:00:00Z',
         bookingLimitDatetime: '2020-12-25T22:00:00Z',
         stockId: '2E',
@@ -212,7 +205,7 @@ describe('pcapi', () => {
   describe('createStock', () => {
     it('should create stock given its offerId and properties', () => {
       // when
-      createStock({
+      pcapi.createStock({
         offerId: 'AE',
         beginningDatetime: '2020-12-24T23:00:00Z',
         bookingLimitDatetime: '2020-12-22T23:59:59Z',
@@ -237,7 +230,7 @@ describe('pcapi', () => {
       const url = 'http://ma-mauvaise-url'
 
       // when
-      getURLErrors(url)
+      pcapi.getURLErrors(url)
 
       // then
       expect(client.post).toHaveBeenCalledWith(`/offers/thumbnail-url-validation`, {

--- a/src/repository/pcapi/offerers.js
+++ b/src/repository/pcapi/offerers.js
@@ -1,0 +1,7 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+export default {
+  getValidatedOfferers: () => {
+    return client.get('/offerers?validated=true')
+  },
+}

--- a/src/repository/pcapi/offers.js
+++ b/src/repository/pcapi/offers.js
@@ -1,0 +1,110 @@
+import { DEFAULT_SEARCH_FILTERS, DEFAULT_PAGE } from 'components/pages/Offers/_constants'
+import { client } from 'repository/pcapi/pcapiClient'
+import { stringify } from 'utils/query-string'
+
+const createRequestBody = searchFilters => {
+  const body = {}
+  Object.keys(DEFAULT_SEARCH_FILTERS).forEach(field => {
+    if (searchFilters[field] && searchFilters[field] !== DEFAULT_SEARCH_FILTERS[field]) {
+      body[field] = searchFilters[field]
+    }
+  })
+
+  if (searchFilters.page) {
+    body.page = searchFilters.page
+  }
+
+  if (searchFilters.periodBeginningDate !== DEFAULT_SEARCH_FILTERS.periodBeginningDate) {
+    body.periodBeginningDate = searchFilters.periodBeginningDate
+  }
+
+  if (searchFilters.periodEndingDate !== DEFAULT_SEARCH_FILTERS.periodEndingDate) {
+    body.periodEndingDate = searchFilters.periodEndingDate
+  }
+
+  return body
+}
+
+export default {
+  loadOffer: async offerId => {
+    return client.get(`/offers/${offerId}`)
+  },
+
+  createOffer: offer => {
+    return client.post(`/offers`, offer)
+  },
+
+  updateOffer: (offerId, offer) => {
+    return client.patch(`/offers/${offerId}`, offer)
+  },
+
+  loadFilteredOffers: async ({
+    name = DEFAULT_SEARCH_FILTERS.name,
+    offererId = DEFAULT_SEARCH_FILTERS.offererId,
+    venueId = DEFAULT_SEARCH_FILTERS.venueId,
+    typeId = DEFAULT_SEARCH_FILTERS.typeId,
+    page = DEFAULT_PAGE,
+    periodBeginningDate = DEFAULT_SEARCH_FILTERS.periodBeginningDate,
+    periodEndingDate = DEFAULT_SEARCH_FILTERS.periodEndingDate,
+    status = DEFAULT_SEARCH_FILTERS.status,
+    creationMode = DEFAULT_SEARCH_FILTERS.creationMode,
+  }) => {
+    const body = createRequestBody({
+      name,
+      offererId,
+      venueId,
+      typeId,
+      page,
+      status,
+      creationMode,
+      periodBeginningDate,
+      periodEndingDate,
+    })
+
+    const queryParams = stringify(body)
+    return client.get(`/offers?${queryParams}`)
+  },
+
+  updateOffersActiveStatus: (
+    areAllOffersSelected,
+    {
+      name = DEFAULT_SEARCH_FILTERS.name,
+      offererId = DEFAULT_SEARCH_FILTERS.offererId,
+      venueId = DEFAULT_SEARCH_FILTERS.venueId,
+      typeId = DEFAULT_SEARCH_FILTERS.typeId,
+      status = DEFAULT_SEARCH_FILTERS.status,
+      creationMode = DEFAULT_SEARCH_FILTERS.creationMode,
+      page = DEFAULT_PAGE,
+      ids = [],
+      isActive,
+      periodBeginningDate = DEFAULT_SEARCH_FILTERS.periodBeginningDate,
+      periodEndingDate = DEFAULT_SEARCH_FILTERS.periodEndingDate,
+    }
+  ) => {
+    const formattedBody = createRequestBody({
+      name,
+      offererId,
+      venueId,
+      typeId,
+      page,
+      status,
+      creationMode,
+      periodBeginningDate,
+      periodEndingDate,
+    })
+
+    if (areAllOffersSelected) {
+      return client.patch('/offers/all-active-status', { ...formattedBody, isActive })
+    }
+
+    return client.patch('/offers/active-status', { ids, isActive })
+  },
+
+  setAllVenueOffersActivate: async venueId => {
+    return client.put(`/venues/${venueId}/offers/activate`)
+  },
+
+  setAllVenueOffersInactivate: async venueId => {
+    return client.put(`/venues/${venueId}/offers/deactivate`)
+  },
+}

--- a/src/repository/pcapi/pcapi.js
+++ b/src/repository/pcapi/pcapi.js
@@ -1,160 +1,17 @@
-import { DEFAULT_SEARCH_FILTERS, DEFAULT_PAGE } from 'components/pages/Offers/_constants'
-import { client } from 'repository/pcapi/pcapiClient'
-import { stringify } from 'utils/query-string'
+import offerers from './offerers'
+import offers from './offers'
+import stocks from './stocks'
+import thumbnails from './thumbnails'
+import types from './types'
+import users from './users'
+import venues from './venues'
 
-//
-// offers
-//
-export const loadOffer = async offerId => {
-  return client.get(`/offers/${offerId}`)
-}
-
-export const createOffer = offer => {
-  return client.post(`/offers`, offer)
-}
-
-export const updateOffer = (offerId, offer) => {
-  return client.patch(`/offers/${offerId}`, offer)
-}
-
-export const loadFilteredOffers = async ({
-  name = DEFAULT_SEARCH_FILTERS.name,
-  offererId = DEFAULT_SEARCH_FILTERS.offererId,
-  venueId = DEFAULT_SEARCH_FILTERS.venueId,
-  typeId = DEFAULT_SEARCH_FILTERS.typeId,
-  page = DEFAULT_PAGE,
-  periodBeginningDate = DEFAULT_SEARCH_FILTERS.periodBeginningDate,
-  periodEndingDate = DEFAULT_SEARCH_FILTERS.periodEndingDate,
-  status = DEFAULT_SEARCH_FILTERS.status,
-  creationMode = DEFAULT_SEARCH_FILTERS.creationMode,
-}) => {
-  const body = createRequestBody({
-    name,
-    offererId,
-    venueId,
-    typeId,
-    page,
-    status,
-    creationMode,
-    periodBeginningDate,
-    periodEndingDate,
-  })
-
-  const queryParams = stringify(body)
-  return client.get(`/offers?${queryParams}`)
-}
-
-export const updateOffersActiveStatus = (
-  areAllOffersSelected,
-  {
-    name = DEFAULT_SEARCH_FILTERS.name,
-    offererId = DEFAULT_SEARCH_FILTERS.offererId,
-    venueId = DEFAULT_SEARCH_FILTERS.venueId,
-    typeId = DEFAULT_SEARCH_FILTERS.typeId,
-    status = DEFAULT_SEARCH_FILTERS.status,
-    creationMode = DEFAULT_SEARCH_FILTERS.creationMode,
-    page = DEFAULT_PAGE,
-    ids = [],
-    isActive,
-    periodBeginningDate = DEFAULT_SEARCH_FILTERS.periodBeginningDate,
-    periodEndingDate = DEFAULT_SEARCH_FILTERS.periodEndingDate,
-  }
-) => {
-  const formattedBody = createRequestBody({
-    name,
-    offererId,
-    venueId,
-    typeId,
-    page,
-    status,
-    creationMode,
-    periodBeginningDate,
-    periodEndingDate,
-  })
-
-  if (areAllOffersSelected) {
-    return client.patch('/offers/all-active-status', { ...formattedBody, isActive })
-  }
-
-  return client.patch('/offers/active-status', { ids, isActive })
-}
-
-const createRequestBody = searchFilters => {
-  const body = {}
-  Object.keys(DEFAULT_SEARCH_FILTERS).forEach(field => {
-    if (searchFilters[field] && searchFilters[field] !== DEFAULT_SEARCH_FILTERS[field]) {
-      body[field] = searchFilters[field]
-    }
-  })
-
-  if (searchFilters.page) {
-    body.page = searchFilters.page
-  }
-
-  if (searchFilters.periodBeginningDate !== DEFAULT_SEARCH_FILTERS.periodBeginningDate) {
-    body.periodBeginningDate = searchFilters.periodBeginningDate
-  }
-
-  if (searchFilters.periodEndingDate !== DEFAULT_SEARCH_FILTERS.periodEndingDate) {
-    body.periodEndingDate = searchFilters.periodEndingDate
-  }
-
-  return body
-}
-
-export const setAllVenueOffersActivate = async venueId => {
-  return client.put(`/venues/${venueId}/offers/activate`)
-}
-
-export const setAllVenueOffersInactivate = async venueId => {
-  return client.put(`/venues/${venueId}/offers/deactivate`)
-}
-
-export const getValidatedOfferers = () => {
-  return client.get('/offerers?validated=true')
-}
-
-export const getVenuesForOfferer = offererId => {
-  if (offererId) {
-    return client.get(`/venues?offererId=${offererId}`)
-  } else {
-    return client.get('/venues')
-  }
-}
-
-//
-// types
-//
-export const loadTypes = () => {
-  return client.get('/types')
-}
-
-//
-// stocks
-//
-export const bulkCreateOrEditStock = (offerId, stocks) => {
-  return client.post(`/stocks/bulk`, {
-    offerId,
-    stocks,
-  })
-}
-
-export const updateStock = stock => {
-  const { stockId, ...stockWithoutId } = stock
-  return client.patch(`/stocks/${stockId}`, stockWithoutId)
-}
-
-export const deleteStock = stockId => {
-  return client.delete(`/stocks/${stockId}`)
-}
-
-export const createStock = stock => {
-  return client.post('/stocks', stock)
-}
-
-//
-// thumbnail
-//
-export const getURLErrors = url => {
-  return client.post('/offers/thumbnail-url-validation', { url: url })
+export default {
+  ...offers,
+  ...offerers,
+  ...stocks,
+  ...users,
+  ...thumbnails,
+  ...types,
+  ...venues,
 }

--- a/src/repository/pcapi/stocks.js
+++ b/src/repository/pcapi/stocks.js
@@ -1,0 +1,16 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+export default {
+  updateStock: stock => {
+    const { stockId, ...stockWithoutId } = stock
+    return client.patch(`/stocks/${stockId}`, stockWithoutId)
+  },
+
+  deleteStock: stockId => {
+    return client.delete(`/stocks/${stockId}`)
+  },
+
+  createStock: stock => {
+    return client.post('/stocks', stock)
+  },
+}

--- a/src/repository/pcapi/thumbnails.js
+++ b/src/repository/pcapi/thumbnails.js
@@ -1,0 +1,7 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+export default {
+  getURLErrors: url => {
+    return client.post('/offers/thumbnail-url-validation', { url: url })
+  },
+}

--- a/src/repository/pcapi/types.js
+++ b/src/repository/pcapi/types.js
@@ -1,0 +1,7 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+export default {
+  loadTypes: () => {
+    return client.get('/types')
+  },
+}

--- a/src/repository/pcapi/users.js
+++ b/src/repository/pcapi/users.js
@@ -1,0 +1,33 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+// src/components/layout/Header/Signout/SignoutButton.jsx:        apiPath: '/users/signout',
+// src/components/pages/LostPassword/LostPasswordContainer.js:          apiPath: '/users/reset-password',
+// src/components/pages/LostPassword/LostPasswordContainer.js:        apiPath: '/users/new-password',
+// src/components/pages/Profil/Profil.jsx:      apiPath: '/users/current',
+// src/components/pages/Profil/tests/Profil.spec.jsx:        apiPath: '/users/current',
+// src/components/pages/Signin/SigninContainer.js:        apiPath: '/users/signin',
+// src/components/pages/Signup/SignupForm/SignupFormContainer.js:        apiPath: '/users/signup/pro',
+// src/components/pages/Signup/SignupForm/__specs__/SignupFormContainer.spec.js:            apiPath: '/users/signup/pro',
+// src/components/pages/Signup/SignupForm/__specs__/SignupFormContainer.spec.js:            apiPath: '/users/signup/pro',
+// src/components/pages/Signup/SignupForm/__specs__/SignupFormContainer.spec.js:            apiPath: '/users/signup/pro',
+
+export default {
+  getCurrentUser: () => {
+    return client.get('/users/current')
+  },
+  signOut: () => {
+    return Promise.resolve('TODO: api call signOut')
+  },
+  resetPassword: () => {
+    return Promise.resolve('TODO: api call resetPassword')
+  },
+  newPassword: () => {
+    return Promise.resolve('TODO: api call newPassword')
+  },
+  signIn: () => {
+    return Promise.resolve('TODO: api call signIn')
+  },
+  signUpPro: () => {
+    return Promise.resolve('TODO: api call signUpPro')
+  },
+}

--- a/src/repository/pcapi/venues.js
+++ b/src/repository/pcapi/venues.js
@@ -1,0 +1,11 @@
+import { client } from 'repository/pcapi/pcapiClient'
+
+export default {
+  getVenuesForOfferer: offererId => {
+    if (offererId) {
+      return client.get(`/venues?offererId=${offererId}`)
+    } else {
+      return client.get('/venues')
+    }
+  },
+}

--- a/src/store/offers/thunks.js
+++ b/src/store/offers/thunks.js
@@ -1,4 +1,4 @@
-import * as pcapi from 'repository/pcapi/pcapi'
+import pcapi from 'repository/pcapi/pcapi'
 import { setMediations, setStocks, setVenues } from 'store/reducers/data'
 
 import { setOffers } from './actions'

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -3,6 +3,7 @@ import { combineReducers } from 'redux'
 import { tracker } from 'store/reducers/tracker'
 
 import { offersReducer } from '../offers/reducer'
+import { usersReducer } from '../users/reducer'
 
 import bookingSummary from './bookingSummary/bookingSummary'
 import data from './data'
@@ -19,6 +20,7 @@ const rootReducer = combineReducers({
   form,
   modal,
   offers: offersReducer,
+  users: usersReducer,
   notification: notificationReducer,
   tracker,
   maintenance: maintenanceReducer,

--- a/src/store/testUtils.js
+++ b/src/store/testUtils.js
@@ -1,22 +1,11 @@
 import merge from 'lodash.merge'
 
 import configureStore from 'store'
-import { initialState as offersInitialState } from 'store/offers/reducer'
-import { initialState as bookingSummaryInitialState } from 'store/reducers/bookingSummary/bookingSummary'
-import { initialState as dataInitialState } from 'store/reducers/data'
-import { initialState as errorsInitialState } from 'store/reducers/errors'
-import { initialState as maintenanceInitialState } from 'store/reducers/maintenanceReducer'
-import { initialState as modalInitialState } from 'store/reducers/modal'
+import rootReducer from 'store/reducers'
 
-export const configureTestStore = overrideData => {
-  const initialData = {
-    bookingSummary: bookingSummaryInitialState,
-    data: dataInitialState,
-    errors: errorsInitialState,
-    maintenance: maintenanceInitialState,
-    modal: modalInitialState,
-    offers: offersInitialState,
-  }
+export const configureTestStore = overrideState => {
+  const emptyAction = { type: '' }
+  const initialState = rootReducer(undefined, emptyAction)
 
-  return configureStore(merge(initialData, overrideData)).store
+  return configureStore(merge(initialState, overrideState)).store
 }

--- a/src/store/users/actions.js
+++ b/src/store/users/actions.js
@@ -1,0 +1,6 @@
+export const SET_USER = 'SET_USER'
+
+export const setCurrentUser = user => ({
+  user,
+  type: SET_USER,
+})

--- a/src/store/users/reducer.js
+++ b/src/store/users/reducer.js
@@ -1,0 +1,15 @@
+import { SET_USER } from './actions'
+
+export const initialState = {
+  currentUser: null,
+}
+
+export const usersReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_USER: {
+      return { ...state, currentUser: action.user }
+    }
+    default:
+      return state
+  }
+}

--- a/src/store/users/thunks.js
+++ b/src/store/users/thunks.js
@@ -1,0 +1,12 @@
+import pcapi from 'repository/pcapi/pcapi'
+
+import { setCurrentUser } from './actions'
+
+export const getCurrentUser = () => {
+  return dispatch => {
+    return pcapi.getCurrentUser().then(rawUser => {
+      const user = rawUser ? rawUser : null
+      dispatch(setCurrentUser(user))
+    })
+  }
+}


### PR DESCRIPTION
On à commencé à migrer `getCurrentUsers` de requestData par pcapi / redux thunk

Voila la liste de toutes les methods pcapi qu'il reste à ajouter.

```
export default {
  getCurrentUser: () => {
    return client.get('/users/current')
    return Promise.resolve('TODO: api call getCurrentUsers')
  },
  signOut: () => {
    return Promise.resolve('TODO: api call signOut')
  },
  resetPassword: () => {
    return Promise.resolve('TODO: api call resetPassword')
  },
  newPassword: () => {
    return Promise.resolve('TODO: api call newPassword')
  },
  signIn: () => {
    return Promise.resolve('TODO: api call signIn')
  },
  signUpPro: () => {
    return Promise.resolve('TODO: api call signUpPro')
  },
}

```