### PR TITLE
(PC-5923) : Fix OfferForm api sent values

### DIFF
--- a/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
@@ -8,9 +8,7 @@ import OfferFormContainer from './OfferForm/OfferFormContainer'
 import OfferThumbnail from './OfferThumbnail/OfferThumbnail'
 import OfferThumbnailPlaceholder from './OfferThumbnail/OfferThumbnailPlaceholder/OfferThumbnailPlaceholder'
 
-const OfferDetails = props => {
-  const { history, isUserAdmin, location, offer } = props
-
+const OfferDetails = ({ history, isUserAdmin, location, offer }) => {
   const [formInitialValues, setFormInitialValues] = useState({})
   const [formErrors, setFormErrors] = useState({})
   const [showThumbnailForm, setShowThumbnailForm] = useState(false)
@@ -100,7 +98,10 @@ const OfferDetails = props => {
 }
 
 OfferDetails.propTypes = {
+  history: PropTypes.shape().isRequired,
   isUserAdmin: PropTypes.bool.isRequired,
+  location: PropTypes.shape().isRequired,
+  offer: PropTypes.shape().isRequired,
 }
 
 export default OfferDetails

--- a/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
@@ -11,8 +11,7 @@ import OfferThumbnailPlaceholder from './OfferThumbnail/OfferThumbnailPlaceholde
 const OfferDetails = ({ history, isUserAdmin, location, offer }) => {
   const [formInitialValues, setFormInitialValues] = useState({})
   const [formErrors, setFormErrors] = useState({})
-  const [showThumbnailForm, setShowThumbnailForm] = useState(false)
-  const [thumbnailUrl, setThumbnailUrl] = useState(null)
+  const [showThumbnailForm, setShowThumbnailForm] = useState(offer !== null)
 
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search)
@@ -29,14 +28,6 @@ const OfferDetails = ({ history, isUserAdmin, location, offer }) => {
       }))
     }
   }, [setFormInitialValues, location.search])
-
-  useEffect(() => {
-    setShowThumbnailForm(true)
-
-    if (offer) {
-      setThumbnailUrl(offer.thumbUrl)
-    }
-  }, [offer])
 
   const handleSubmitOffer = useCallback(
     async offerValues => {
@@ -89,7 +80,11 @@ const OfferDetails = ({ history, isUserAdmin, location, offer }) => {
 
         {showThumbnailForm && (
           <div className="sidebar">
-            {thumbnailUrl ? <OfferThumbnail url={thumbnailUrl} /> : <OfferThumbnailPlaceholder />}
+            {offer?.thumbUrl ? (
+              <OfferThumbnail url={offer.thumbUrl} />
+            ) : (
+              <OfferThumbnailPlaceholder />
+            )}
           </div>
         )}
       </div>

--- a/src/components/pages/Offer/Offer/OfferDetails/OfferForm/_constants.js
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferForm/_constants.js
@@ -25,4 +25,26 @@ export const DEFAULT_FORM_VALUES = {
   withdrawalDetails: TEXT_INPUT_DEFAULT_VALUE,
 }
 
+export const BASE_OFFER_FIELDS = ['description', 'name', 'type', 'venueId', 'withdrawalDetails']
+export const EDITED_OFFER_READ_ONLY_FIELDS = [
+  'type',
+  'musicType',
+  'musicSubType',
+  'offererId',
+  'showType',
+  'showSubType',
+  'venueId',
+]
+export const EXTRA_DATA_FIELDS = [
+  'author',
+  'isbn',
+  'musicType',
+  'musicSubType',
+  'performer',
+  'showType',
+  'showSubType',
+  'speaker',
+  'stageDirector',
+  'visa',
+]
 export const MANDATORY_FIELDS = ['name', 'venueId', 'offererId', 'url', 'bookingEmail']

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreation.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreation.spec.jsx
@@ -8,7 +8,7 @@ import { MemoryRouter, Route } from 'react-router'
 import * as pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
-import OfferDetailsContainer from '../../OfferLayoutContainer'
+import OfferLayoutContainer from '../../OfferLayoutContainer'
 import { DEFAULT_FORM_VALUES } from '../OfferForm/_constants'
 
 import { getInputErrorForField, getOfferInputForField, setOfferValues } from './helpers'
@@ -26,7 +26,7 @@ const renderOffers = async (props, store, queryParams = null) => {
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: '/offres/v2/creation', search: queryParams }]}>
           <Route path="/offres/v2/">
-            <OfferDetailsContainer {...props} />
+            <OfferLayoutContainer {...props} />
           </Route>
         </MemoryRouter>
       </Provider>

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreation.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferCreation.spec.jsx
@@ -755,7 +755,6 @@ describe('offerDetails - Creation', () => {
         durationMinutes: '03:00',
         type: 'EventType.TEST_MUSIQUE',
         extraData: {
-          author: null,
           musicType: '501',
           musicSubType: '502',
           performer: 'TEST PERFORMER NAME',

--- a/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
@@ -9,7 +9,7 @@ import { getProviderInfo } from 'components/pages/Offer/LocalProviderInformation
 import * as pcapi from 'repository/pcapi/pcapi'
 import { configureTestStore } from 'store/testUtils'
 
-import OfferDetailsContainer from '../../OfferLayoutContainer'
+import OfferLayoutContainer from '../../OfferLayoutContainer'
 import { DEFAULT_FORM_VALUES } from '../OfferForm/_constants'
 
 import { fieldLabels, getInputErrorForField, setOfferValues } from './helpers'
@@ -30,7 +30,7 @@ const renderOffers = async (props, store, queryParams = '') => {
           initialEntries={[{ pathname: '/offres/v2/ABC12/edition', search: queryParams }]}
         >
           <Route path="/offres/v2/:offerId([A-Z0-9]+)/">
-            <OfferDetailsContainer {...props} />
+            <OfferLayoutContainer {...props} />
           </Route>
         </MemoryRouter>
       </Provider>

--- a/src/components/pages/Offer/Offer/__specs__/OfferLayout.spec.jsx
+++ b/src/components/pages/Offer/Offer/__specs__/OfferLayout.spec.jsx
@@ -25,7 +25,7 @@ const renderOfferDetails = async (props, store) => {
   })
 }
 
-describe('offerDetails', () => {
+describe('offerLayout', () => {
   let editedOffer
   let props
   let store

--- a/src/components/pages/Venue/utils/__specs__/formatPatch.spec.js
+++ b/src/components/pages/Venue/utils/__specs__/formatPatch.spec.js
@@ -7,7 +7,7 @@ describe('formatPatch', () => {
       const patch = {
         address: 'RUE DIDEROT',
         bic: 'QSDFGH8Z564',
-        bookingEmail: 'R6465373fake674654673@email.com',
+        bookingEmail: 'R6465373fake674654673sub@example.com',
         city: 'Aulnay-sous-Bois',
         comment: '',
         dateModifiedAtLastProvider: '2019-02-05T09:37:37.776590Z',
@@ -35,7 +35,7 @@ describe('formatPatch', () => {
       const expected = {
         address: 'RUE DIDEROT',
         bic: 'QSDFGH8Z564',
-        bookingEmail: 'R6465373fake674654673@email.com',
+        bookingEmail: 'R6465373fake674654673sub@example.com',
         city: 'Aulnay-sous-Bois',
         comment: '',
         iban: 'FR7630001007941234567890185',
@@ -60,7 +60,7 @@ describe('formatPatch', () => {
       const patch = {
         address: 'RUE DIDEROT',
         bic: 'QSDFGH8Z564',
-        bookingEmail: 'R6465373fake674654673@email.com',
+        bookingEmail: 'R6465373fake674654673sub@example.com',
         city: 'Aulnay-sous-Bois',
         comment: 'comment',
         dateModifiedAtLastProvider: '2019-02-05T09:37:37.776590Z',
@@ -89,7 +89,7 @@ describe('formatPatch', () => {
       // then
       expect(result).toStrictEqual({
         address: 'RUE DIDEROT',
-        bookingEmail: 'R6465373fake674654673@email.com',
+        bookingEmail: 'R6465373fake674654673sub@example.com',
         comment: 'comment',
         city: 'Aulnay-sous-Bois',
         latitude: 48.92071,

--- a/src/components/utils/mocks/state.js
+++ b/src/components/utils/mocks/state.js
@@ -808,7 +808,7 @@ const state = {
       {
         id: 'CY',
         address: 'RUE DES POMMES ROSAS',
-        bookingEmail: 'fake@email.com',
+        bookingEmail: 'fake@example.com',
         city: 'Cayenne',
         comment: null,
         dateModifiedAtLastProvider: '2019-03-07T10:40:03.216279Z',


### PR DESCRIPTION
  form's default values cannot be used as is to assign a api default empty value
Example: checkbox isDuo default form value is "true" and we don't want
it to become "null" if it's unchange.

=====

https://passculture.atlassian.net/browse/PC-5923