### PR TITLE
[quick win] adding of silent flag on jest only on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
-            yarn test:unit --coverage
+            yarn test:unit --coverage --silent
             yarn coveralls
             bash <(curl -s https://codecov.io/bash)
       - run:


### PR DESCRIPTION
Etant donné que nous avons plein de `console.warning` et `console.error` qui sont difficile à enlever et qui ajoutent beaucoup de bruit et donc du temps à la CI, je propose de ne plus les afficher **juste pour la CI**.
On gagne environ 20% de temps.