### PR TITLE
(PC-5717): fix toaster icon size

### DIFF
--- a/src/styles/components/layout/NotificationV2/_NotificationV2.scss
+++ b/src/styles/components/layout/NotificationV2/_NotificationV2.scss
@@ -67,7 +67,7 @@
   }
 
   img {
-    height: rem(40px);
+    flex: 0 0 rem(40px);
     padding-right: rem(8px);
     width: rem(40px);
   }


### PR DESCRIPTION
Flex est plus fort que width & height, il faut lui indiqué de ne pas s'auto resizer, avec un valeur maximum possible égale à la width demandée.