### PR TITLE
[PC-6411] Fix checkbox position with multiline label

### DIFF
--- a/src/components/layout/inputs/CheckboxInput/CheckboxInput.jsx
+++ b/src/components/layout/inputs/CheckboxInput/CheckboxInput.jsx
@@ -18,6 +18,7 @@ export const CheckboxInput = ({
   if (hiddenLabel) {
     textClasses.push('label-hidden')
   }
+  inputClasses.push('input-checkbox-input')
 
   return (
     <label

--- a/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
+++ b/src/styles/components/layout/inputs/CheckboxInput/_CheckboxInput.scss
@@ -78,6 +78,11 @@ input[type="checkbox"] {
 }
 
 .field-checkbox {
+  .input-checkbox-input {
+    align-self: flex-start;
+    margin-top: 3px;
+  }
+
   svg {
     margin-right: rem(5px);
   }


### PR DESCRIPTION
Erreur du linter css qui check l'ordre alphabétique des css compilé et non de chaque niveau de scss.
J'espère que la ci vas tout de meme passer ...