### PR TITLE
[PC-6771] OfferForm: fix offer not refresh on form submit

### DIFF
--- a/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
+++ b/src/components/pages/Offer/Offer/OfferDetails/OfferDetails.jsx
@@ -17,6 +17,7 @@ const OfferDetails = ({
   isUserAdmin,
   location,
   offer,
+  reloadOffer,
   showCreationSuccessNotification,
   showEditionSuccessNotification,
   showErrorNotification,
@@ -65,14 +66,14 @@ const OfferDetails = ({
               croppingRect.height
             )
           }
-          history.push(`/offres/${offer.id}/edition`)
+          reloadOffer()
+          setFormErrors({})
         } else {
           const response = await pcapi.createOffer(offerValues)
           showCreationSuccessNotification()
           const createdOfferId = response.id
           history.push(`/offres/${createdOfferId}/stocks`)
         }
-        setFormErrors({})
       } catch (error) {
         if (error && 'errors' in error) {
           const mapApiErrorsToFormErrors = {
@@ -96,6 +97,7 @@ const OfferDetails = ({
       formValues.offererId,
       history,
       offer,
+      reloadOffer,
       showCreationSuccessNotification,
       showEditionSuccessNotification,
       showErrorNotification,
@@ -173,6 +175,7 @@ const OfferDetails = ({
 
 OfferDetails.defaultProps = {
   offer: null,
+  reloadOffer: null,
 }
 
 OfferDetails.propTypes = {
@@ -180,6 +183,7 @@ OfferDetails.propTypes = {
   isUserAdmin: PropTypes.bool.isRequired,
   location: PropTypes.shape().isRequired,
   offer: PropTypes.shape(),
+  reloadOffer: PropTypes.func,
   showCreationSuccessNotification: PropTypes.func.isRequired,
   showEditionSuccessNotification: PropTypes.func.isRequired,
   showErrorNotification: PropTypes.func.isRequired,

--- a/src/components/pages/Offer/Offer/OfferLayout.jsx
+++ b/src/components/pages/Offer/Offer/OfferLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useCallback, useEffect, useState, useRef } from 'react'
 import { Switch, Route } from 'react-router-dom'
 
 import Titles from 'components/layout/Titles/Titles'
@@ -22,16 +22,24 @@ const OfferLayout = props => {
   const isCreatingOffer = useRef(!match.params.offerId)
   const [offer, setOffer] = useState(null)
 
-  useEffect(() => {
-    async function loadOffer(offerId) {
+  const loadOffer = useCallback(
+    async offerId => {
       const existingOffer = await pcapi.loadOffer(offerId)
       setOffer(existingOffer)
-    }
+    },
+    [setOffer]
+  )
 
+  const reloadOffer = useCallback(async () => (offer.id ? loadOffer(offer.id) : false), [
+    loadOffer,
+    offer,
+  ])
+
+  useEffect(() => {
     if (match.params.offerId) {
       loadOffer(match.params.offerId)
     }
-  }, [match.params.offerId])
+  }, [loadOffer, match.params.offerId])
 
   const stepName = location.pathname.match(/[a-z]+$/)
   const activeStep = stepName ? mapPathToStep[stepName[0]] : null
@@ -68,7 +76,10 @@ const OfferLayout = props => {
             exact
             path={`${match.url}/edition`}
           >
-            <OfferDetailsContainer offer={offer} />
+            <OfferDetailsContainer
+              offer={offer}
+              reloadOffer={reloadOffer}
+            />
           </Route>
           <Route
             exact


### PR DESCRIPTION
* Aller sur le détail d’un offre. Exemple https://pro.passculture-testing.beta.gouv.fr/offres/A9PDE/edition
* Modifier la description par exemple. 
* Cliquer sur Enregistrer
* Aller sur les stocks en cloquant en haut sur “Stock et prix” 
* Revenir sur le détail de l’offre en cliquant sur “Détail de l’offre” 
* KO -> Le champ description ne contient pas les dernières informations à jour 