### PR TITLE
[PC-6665] home v2, fix bank informations box border

### DIFF
--- a/src/components/pages/Home/Homepage.scss
+++ b/src/components/pages/Home/Homepage.scss
@@ -97,6 +97,7 @@
       @include body();
 
       .ico-bank-warning {
+        margin-left: rem(8px);
         vertical-align: middle;
       }
     }
@@ -109,8 +110,6 @@
       }
 
       .bi-banner {
-        border-radius: 0;
-
         p {
           color: $black;
         }


### PR DESCRIPTION
Revue : KO

les coins des messages jaune et bleu doivent être arrondies

=========================
note: 
La preview à des radius tout petit de 2px, mais apres disuction avec nicolux, on garde les 6px actuel.