### PR TITLE
[PC-6670] Home v2: same width for both actions in create venue box

### DIFF
--- a/src/components/pages/Home/Homepage.scss
+++ b/src/components/pages/Home/Homepage.scss
@@ -206,7 +206,9 @@
         margin-top: rem(24px);
 
         a {
+          flex: 1;
           margin-left: rem(16px);
+          max-width: rem(240px);
 
           &:first-child {
             margin-left: 0;


### PR DESCRIPTION
Revue UI : KO

Le bouton “Créer un lieu” doit être de la même taille que “Créer une offre numérique”