### PR TITLE
[quick win] Removing of getStubStore

### DIFF
--- a/src/components/layout/DownloadButton/__specs__/DownloadButtonContainer.spec.jsx
+++ b/src/components/layout/DownloadButton/__specs__/DownloadButtonContainer.spec.jsx
@@ -3,8 +3,8 @@ import React from 'react'
 import { Provider } from 'react-redux'
 
 import { showNotificationV1 } from 'store/reducers/notificationReducer'
+import { configureTestStore } from 'store/testUtils'
 
-import { getStubStore } from '../../../../utils/stubStore'
 import DownloadButtonContainer from '../DownloadButtonContainer'
 
 global.fetch = url => {
@@ -26,9 +26,7 @@ describe('src | components | Layout | DownloadButtonContainer', () => {
       children: 'Fake title',
       href: 'https://foo.com/reimbursements/csv',
     }
-    const store = getStubStore({
-      data: (state = {}) => state,
-    })
+    const store = configureTestStore()
     jest.spyOn(store, 'dispatch')
 
     // when
@@ -51,9 +49,7 @@ describe('src | components | Layout | DownloadButtonContainer', () => {
       children: 'Fake title',
       href: 'https://foo.com/wrong-url',
     }
-    const store = getStubStore({
-      data: (state = {}) => state,
-    })
+    const store = configureTestStore()
     jest.spyOn(store, 'dispatch')
 
     // when

--- a/src/components/layout/Header/__specs__/Header.spec.jsx
+++ b/src/components/layout/Header/__specs__/Header.spec.jsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import { getStubStore } from 'utils/stubStore'
+import { configureTestStore } from 'store/testUtils'
 
 import * as constants from '../_constants'
 import Header from '../Header'
@@ -37,10 +37,9 @@ describe('header', () => {
 })
 
 const renderHeader = props => {
-  const stubStore = getStubStore({
-    data: (state = {}) => state,
-  })
-  render(
+  const stubStore = configureTestStore()
+
+  return render(
     <Provider store={stubStore}>
       <MemoryRouter>
         <Header {...props} />

--- a/src/components/layout/NotificationV2/__specs__/NotificationV2.spec.jsx
+++ b/src/components/layout/NotificationV2/__specs__/NotificationV2.spec.jsx
@@ -17,7 +17,6 @@ describe('src | components | layout | NotificationV2', () => {
   let store
 
   beforeEach(() => {
-    store = configureTestStore()
     hideNotification = jest.fn()
     props = {
       hideNotification,
@@ -25,7 +24,9 @@ describe('src | components | layout | NotificationV2', () => {
     }
   })
 
-  const renderNotificationV2 = (props, store) => {
+  const renderNotificationV2 = (props, sentNotification) => {
+    store = configureTestStore({ notification: sentNotification })
+
     return render(
       <Provider store={store}>
         <NotificationV2Container {...props} />
@@ -40,10 +41,9 @@ describe('src | components | layout | NotificationV2', () => {
       type: 'success',
       version: 2,
     }
-    store = configureTestStore({ notification: sentNotification })
 
     // when
-    renderNotificationV2(props, store)
+    renderNotificationV2(props, sentNotification)
 
     // then
     const notification = screen.getByText(sentNotification.text)
@@ -59,10 +59,9 @@ describe('src | components | layout | NotificationV2', () => {
       type: 'success',
       version: 2,
     }
-    store = configureTestStore({ notification: sentNotification })
 
     // when
-    renderNotificationV2(props, store)
+    renderNotificationV2(props, sentNotification)
 
     // then
     expect(screen.getByRole('img')).toHaveAttribute(
@@ -78,10 +77,9 @@ describe('src | components | layout | NotificationV2', () => {
       type: 'error',
       version: 2,
     }
-    store = configureTestStore({ notification: sentNotification })
 
     // when
-    renderNotificationV2(props, store)
+    renderNotificationV2(props, sentNotification)
 
     // then
     expect(screen.getByRole('img')).toHaveAttribute(
@@ -97,10 +95,9 @@ describe('src | components | layout | NotificationV2', () => {
       type: 'success',
       version: 2,
     }
-    store = configureTestStore({ notification: sentNotification })
 
     // when
-    renderNotificationV2(props, store)
+    renderNotificationV2(props, sentNotification)
 
     // then
     await waitFor(() => {
@@ -115,10 +112,9 @@ describe('src | components | layout | NotificationV2', () => {
       type: 'success',
       version: 2,
     }
-    store = configureTestStore({ notification: sentNotification })
 
     // when
-    renderNotificationV2(props, store)
+    renderNotificationV2(props, sentNotification)
 
     // then
     await waitFor(() => {

--- a/src/components/pages/Bookings/BookingsRecapTable/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
+++ b/src/components/pages/Bookings/BookingsRecapTable/CellsFormatter/__specs__/BookingStatusCell.spec.jsx
@@ -4,16 +4,15 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import { getStubStore } from '../../../../../../utils/stubStore'
+import { configureTestStore } from 'store/testUtils'
+
 import BookingStatusCell from '../BookingStatusCell'
 
 const renderBookingStatusCell = props => {
-  const stubbedStore = getStubStore({
-    data: (state = {}) => state,
-  })
+  const store = configureTestStore()
 
-  render(
-    <Provider store={stubbedStore}>
+  return render(
+    <Provider store={store}>
       <MemoryRouter>
         <BookingStatusCell {...props} />
       </MemoryRouter>

--- a/src/components/pages/Desk/__specs__/Desk.spec.jsx
+++ b/src/components/pages/Desk/__specs__/Desk.spec.jsx
@@ -4,28 +4,20 @@ import React from 'react'
 import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
 
-import { getStubStore } from 'utils/stubStore'
+import { configureTestStore } from 'store/testUtils'
 import { queryByTextTrimHtml } from 'utils/testHelpers'
 
 import Desk from '../Desk'
 
 const renderDesk = props => {
-  const stubbedStore = getStubStore({
-    data: (
-      state = {
-        users: [{ publicName: 'USER' }],
-        offerers: [{}],
-      }
-    ) => state,
-    modal: (
-      state = {
-        config: {},
-      }
-    ) => state,
+  const store = configureTestStore({
+    data: {
+      users: [{ publicName: 'USER' }],
+    },
   })
 
   render(
-    <Provider store={stubbedStore}>
+    <Provider store={store}>
       <MemoryRouter>
         <Desk {...props} />
       </MemoryRouter>

--- a/src/components/pages/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
+++ b/src/components/pages/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
@@ -6,8 +6,8 @@ import { Provider } from 'react-redux'
 import { Router } from 'react-router-dom'
 
 import * as usersSelectors from 'store/selectors/data/usersSelectors'
+import { configureTestStore } from 'store/testUtils'
 
-import { getStubStore } from '../../../../../utils/stubStore'
 import AddressField from '../../fields/LocationFields/AddressField'
 import LocationFields from '../../fields/LocationFields/LocationFields'
 import VenueCreation from '../VenueCreation'
@@ -164,18 +164,7 @@ describe('src | components | pages | Venue', () => {
           publicName: 'fake public name',
         }
 
-        const store = getStubStore({
-          data: (
-            state = {
-              offerers: [],
-            }
-          ) => state,
-          modal: (
-            state = {
-              config: {},
-            }
-          ) => state,
-        })
+        const store = configureTestStore()
         const history = createBrowserHistory()
         history.push(`/structures/AE/lieux/TR?modification`)
 

--- a/src/components/pages/Venue/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
+++ b/src/components/pages/Venue/VenueEdition/VenueProvidersManager/StocksProviderForm/__specs__/StocksProviderForm.spec.jsx
@@ -9,17 +9,17 @@ import { configureTestStore } from 'store/testUtils'
 import * as fetch from 'utils/fetch'
 
 const renderStocksProviderForm = props => {
-  const stubbedStore = configureTestStore({ notification: {} })
+  const store = configureTestStore({ notification: {} })
 
   render(
-    <Provider store={stubbedStore}>
+    <Provider store={store}>
       <MemoryRouter>
         <StocksProviderFormContainer {...props} />
       </MemoryRouter>
     </Provider>
   )
 
-  return stubbedStore
+  return store
 }
 
 describe('src | StocksProviderForm', () => {
@@ -94,7 +94,7 @@ describe('src | StocksProviderForm', () => {
 
     it('should display a notification if there is something wrong with the server', async () => {
       // given
-      const stubbedStore = renderStocksProviderForm(props)
+      const store = renderStocksProviderForm(props)
       jest.spyOn(global, 'fetch').mockResolvedValue({
         json: () => Promise.resolve({ errors: ['error message'] }),
         ok: false,
@@ -106,7 +106,7 @@ describe('src | StocksProviderForm', () => {
 
       // then
       expect(props.cancelProviderSelection).toHaveBeenCalledTimes(1)
-      expect(stubbedStore.getState().notification).toStrictEqual({
+      expect(store.getState().notification).toStrictEqual({
         text: 'error message',
         type: 'danger',
         version: 1,

--- a/src/components/pages/Venue/VenueEdition/__specs__/VenueEdition.spec.jsx
+++ b/src/components/pages/Venue/VenueEdition/__specs__/VenueEdition.spec.jsx
@@ -6,8 +6,8 @@ import { Provider } from 'react-redux'
 import { Router } from 'react-router-dom'
 
 import * as usersSelectors from 'store/selectors/data/usersSelectors'
+import { configureTestStore } from 'store/testUtils'
 
-import { getStubStore } from '../../../../../utils/stubStore'
 import AddressField from '../../fields/LocationFields/AddressField'
 import LocationFields from '../../fields/LocationFields/LocationFields'
 import VenueEdition from '../VenueEdition'
@@ -116,20 +116,7 @@ describe('src | components | pages | VenueEdition', () => {
           },
         }
 
-        const store = getStubStore({
-          data: (
-            state = {
-              offerers: [],
-              providers: [],
-              venueProviders: [],
-            }
-          ) => state,
-          modal: (
-            state = {
-              config: {},
-            }
-          ) => state,
-        })
+        const store = configureTestStore()
         const history = createBrowserHistory()
         history.push(`/structures/AE/lieux/TR?modification`)
 
@@ -191,20 +178,7 @@ describe('src | components | pages | VenueEdition', () => {
             id: 'CM',
           }
 
-          const store = getStubStore({
-            data: (
-              state = {
-                offerers: [],
-                providers: [],
-                venueProviders: [],
-              }
-            ) => state,
-            modal: (
-              state = {
-                config: {},
-              }
-            ) => state,
-          })
+          const store = configureTestStore()
           const history = createMemoryHistory()
           history.push('/structures/APEQ/lieux/CM')
 

--- a/src/store/reducers/notificationReducer.js
+++ b/src/store/reducers/notificationReducer.js
@@ -3,7 +3,7 @@ export const CLOSE_NOTIFICATION = 'CLOSE_NOTIFICATION'
 export const SHOW_NOTIFICATION_V1 = 'SHOW_NOTIFICATION_V1'
 export const SHOW_NOTIFICATION_V2 = 'SHOW_NOTIFICATION_V2'
 
-const initialState = {}
+export const initialState = {}
 
 export const notificationReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/src/store/testUtils.js
+++ b/src/store/testUtils.js
@@ -7,6 +7,7 @@ import { initialState as dataInitialState } from 'store/reducers/data'
 import { initialState as errorsInitialState } from 'store/reducers/errors'
 import { initialState as maintenanceInitialState } from 'store/reducers/maintenanceReducer'
 import { initialState as modalInitialState } from 'store/reducers/modal'
+import { initialState as notificationInitialState } from 'store/reducers/notificationReducer'
 
 export const configureTestStore = overrideData => {
   const initialData = {
@@ -15,6 +16,7 @@ export const configureTestStore = overrideData => {
     errors: errorsInitialState,
     maintenance: maintenanceInitialState,
     modal: modalInitialState,
+    notification: notificationInitialState,
     offers: offersInitialState,
   }
 

--- a/src/utils/stubStore.js
+++ b/src/utils/stubStore.js
@@ -1,9 +1,0 @@
-import { applyMiddleware, combineReducers, createStore } from 'redux'
-import createSagaMiddleware from 'redux-saga'
-
-export const getStubStore = reducers => {
-  const enhancer = applyMiddleware(createSagaMiddleware())
-  const reducer = combineReducers(reducers)
-
-  return createStore(reducer, enhancer)
-}


### PR DESCRIPTION
`getStubStore` n'étant plus utile au profit de `configureTestStore`, il a disparu pour éviter l'effet de la [broken window](https://en.wikipedia.org/wiki/Broken_windows_theory).