### PR TITLE
webpack: Ignore Emacs lock files on development server

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -89,7 +89,7 @@ module.exports = function (proxy, allowedHost) {
     // src/node_modules is not ignored to support absolute imports
     // https://github.com/facebook/create-react-app/issues/1065
     watchOptions: {
-      ignored: ignoredFiles(paths.appSrc),
+      ignored: [ignoredFiles(paths.appSrc), '**/.#*'],
     },
     https: getHttpsConfig(),
     host,


### PR DESCRIPTION
Correction similaire à ce que j'avais fait dans la webapp : pass-culture/pass-culture-browser@2928971fb34ce903c5d752040b51eadb1be8096d

----

Emacs may create lock files whose filename starts with ".#". These
files are picked up by the current webpack dev server config. As soon
as I start to edit a JSX file, the server crashes because it tries to
handle the lock file.

Emacs lock files should be ignored.

This may be fixed eventually upstream with facebook/create-react-app#10706
but in the meantime...