### PR TITLE
(PC-7508) Change password error wording

### DIFF
--- a/src/components/layout/form/fields/PasswordField.jsx
+++ b/src/components/layout/form/fields/PasswordField.jsx
@@ -21,6 +21,21 @@ class PasswordField extends PureComponent {
     }
   }
 
+  getErrorMessage = errors => {
+    // When the error reason is identified to be invalid password, we override the backend error message
+    // Why ? For legacy reasons, we used to display the backend error message but the tight couplage has become an hindrance to us
+    if (errors[0].startsWith('Ton mot de passe')) {
+      return `Votre mot de passe doit contenir au moins :
+      - 12 caractères
+      - Un chiffre
+      - Une majuscule et une minuscule
+      - Un caractère spécial
+      `
+    }
+
+    return errors[0]
+  }
+
   handleToggleHidden = e => {
     e.preventDefault()
     this.setState(previousState => ({
@@ -46,7 +61,7 @@ class PasswordField extends PureComponent {
 
     return (
       <TextInputWithIcon
-        error={errors && (meta.touched || meta.modified) ? errors[0] : null}
+        error={errors && (meta.touched || meta.modified) ? this.getErrorMessage(errors) : null}
         icon={isPasswordHidden ? 'ico-eye-close' : 'ico-eye-open'}
         iconAlt={isPasswordHidden ? 'Afficher le mot de passe' : 'Cacher le mot de passe'}
         label={label}

--- a/src/components/layout/form/fields/__specs__/PasswordField.spec.jsx
+++ b/src/components/layout/form/fields/__specs__/PasswordField.spec.jsx
@@ -1,4 +1,9 @@
-import { isNotValid } from '../PasswordField'
+import '@testing-library/jest-dom'
+import { screen, render, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { Form } from 'react-final-form'
+
+import PasswordField, { isNotValid } from '../PasswordField'
 
 describe('component | PasswordField', () => {
   describe('isNotValid', () => {
@@ -12,6 +17,68 @@ describe('component | PasswordField', () => {
       const result = isNotValid('une valeur')
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('rendering', () => {
+    let props = {
+      label: 'labelTest',
+      name: 'nameTest',
+    }
+    it('should display custom error message when backend error starts with "ton mot de passe"', () => {
+      // Given
+      render(
+        <Form onSubmit={jest.fn}>
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <PasswordField
+                {...props}
+                errors={['Ton mot de passe gloubi boulga']}
+              />
+            </form>
+          )}
+        </Form>
+      )
+      fireEvent.click(screen.getByRole('button', { name: 'Afficher le mot de passe' }))
+
+      // When
+      const input = screen.getByRole('textbox', { name: 'labelTest Cacher le mot de passe' })
+      fireEvent.change(input, {
+        target: { value: 'tutu' },
+      })
+
+      // Then
+      expect(
+        screen.getByText(
+          'Votre mot de passe doit contenir au moins : - 12 caractères - Un chiffre - Une majuscule et une minuscule - Un caractère spécial'
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('should display backned error message when backend error does not start with "ton mot de passe"', () => {
+      // Given
+      render(
+        <Form onSubmit={jest.fn}>
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <PasswordField
+                {...props}
+                errors={['An error']}
+              />
+            </form>
+          )}
+        </Form>
+      )
+      fireEvent.click(screen.getByRole('button', { name: 'Afficher le mot de passe' }))
+
+      // When
+      const input = screen.getByRole('textbox', { name: 'labelTest Cacher le mot de passe' })
+      fireEvent.change(input, {
+        target: { value: 'tutu' },
+      })
+
+      // Then
+      expect(screen.getByText('An error')).toBeInTheDocument()
     })
   })
 })

--- a/src/components/pages/SetPassword/__specs__/SetPassword.spec.jsx
+++ b/src/components/pages/SetPassword/__specs__/SetPassword.spec.jsx
@@ -123,7 +123,7 @@ describe('src | components | pages | SetPassword', () => {
 
   it('should display the form error', async () => {
     // Given
-    const passwordErrorMessage = 'character problem'
+    const passwordErrorMessage = 'Ton mot de passe est trop faible'
     pcapi.setPassword.mockRejectedValue({ errors: { newPassword: [passwordErrorMessage] } })
     renderSetPassword(store, history)
     const passwordInput = screen.getByLabelText('Mot de passe')
@@ -138,7 +138,11 @@ describe('src | components | pages | SetPassword', () => {
     // Then
     await waitFor(() => {
       expect(screen.getByText(INVALID_FORM_MESSAGE)).toBeVisible()
-      expect(screen.getByText(passwordErrorMessage)).toBeVisible()
+      expect(
+        screen.getByText(
+          'Votre mot de passe doit contenir au moins : - 12 caractères - Un chiffre - Une majuscule et une minuscule - Un caractère spécial'
+        )
+      ).toBeVisible()
     })
   })
 


### PR DESCRIPTION
Le code partagé directement dans le password/domain entre webapp et pro qui renvoie les messages d'erreurs à afficher côté front cause un gros souci de couplage entre pro et webapp.
C'est très compliqué en l'état de modifier simplement le wording du message d'erreur.
À voir comment on aborde le sujet, peut-être après la suppression de webapp pour éviter du travail inutile mais il faudra enlever ce couplage entre la partie domaine des mots de passes et l'affichage de messages côté front.