### PR TITLE
(PC-8769) Use new /users/tuto-seen route without user id

### DIFF
--- a/src/components/layout/Tutorial/TutorialDialog.jsx
+++ b/src/components/layout/Tutorial/TutorialDialog.jsx
@@ -39,7 +39,7 @@ const TutorialDialog = ({ currentUser, setUserHasSeenTuto }) => {
 
   const closeTutoDialog = useCallback(() => {
     pcapi
-      .setHasSeenTutos(currentUser.id)
+      .setHasSeenTutos()
       .then(() => {
         setUserHasSeenTuto(currentUser)
       })

--- a/src/components/layout/Tutorial/__specs__/TutorialDialog.spec.jsx
+++ b/src/components/layout/Tutorial/__specs__/TutorialDialog.spec.jsx
@@ -144,7 +144,7 @@ describe('tutorial modal', () => {
           await act(async () => {
             await fireEvent.click(buttonFinish)
           })
-          expect(pcapi.setHasSeenTutos).toHaveBeenCalledWith('test_id')
+          expect(pcapi.setHasSeenTutos).toHaveBeenCalledWith()
         })
       })
 

--- a/src/repository/pcapi/__specs__/pcapi.spec.js
+++ b/src/repository/pcapi/__specs__/pcapi.spec.js
@@ -244,12 +244,12 @@ describe('pcapi', () => {
   })
 
   describe('hasSeenTutos', () => {
-    it('should call api patch with user id', () => {
+    it('should call api', () => {
       // when
-      setHasSeenTutos('ABC')
+      setHasSeenTutos()
 
       // then
-      expect(client.patch).toHaveBeenCalledWith('/users/ABC/tuto-seen')
+      expect(client.patch).toHaveBeenCalledWith('/users/tuto-seen')
     })
   })
 

--- a/src/repository/pcapi/__specs__/pcapiClient.spec.js
+++ b/src/repository/pcapi/__specs__/pcapiClient.spec.js
@@ -209,7 +209,7 @@ describe('pcapiClient', () => {
 
     it('should have default value for data', async () => {
       // Given
-      const path = '/users/YJ/tuto-seen'
+      const path = '/users/tuto-seen'
 
       // When
       await client.patch(path, undefined, false)

--- a/src/repository/pcapi/pcapi.js
+++ b/src/repository/pcapi/pcapi.js
@@ -209,8 +209,8 @@ export const setPassword = (token, newPassword) => {
 //
 // tutos
 //
-export const setHasSeenTutos = userId => {
-  return client.patch(`/users/${userId}/tuto-seen`)
+export const setHasSeenTutos = () => {
+  return client.patch(`/users/tuto-seen`)
 }
 
 //


### PR DESCRIPTION
The old route included the user id, which is not necessary. It makes
the backend code slightly simpler.

---

Pull request correspondante côté backend : pass-culture/pass-culture-api#2444.