### PR TITLE
[PC-8599] Move Offerers pages to new route system

### DIFF
--- a/src/components/pages/Offerers/List/Offerers.jsx
+++ b/src/components/pages/Offerers/List/Offerers.jsx
@@ -4,7 +4,6 @@ import { Form } from 'react-final-form'
 import LoadingInfiniteScroll from 'react-loading-infinite-scroller'
 import { Link } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
 import Icon from 'components/layout/Icon'
 import TextInput from 'components/layout/inputs/TextInput/TextInput'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
@@ -173,11 +172,7 @@ class Offerers extends PureComponent {
     )
 
     return (
-      <AppLayout
-        layoutConfig={{
-          pageName: 'offerers',
-        }}
-      >
+      <div className="offerers-page">
         <PageTitle title="Vos structures juridiques" />
         <Titles
           action={actionLink}
@@ -226,7 +221,7 @@ class Offerers extends PureComponent {
           })}
         </LoadingInfiniteScroll>
         {hasMore === false && 'Fin des résultats'}
-      </AppLayout>
+      </div>
     )
   }
 }

--- a/src/components/pages/Offerers/Offerer/OffererDetails/OffererDetails.jsx
+++ b/src/components/pages/Offerers/Offerer/OffererDetails/OffererDetails.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
+import { NavLink } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import Icon from 'components/layout/Icon'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Titles from 'components/layout/Titles/Titles'
 
@@ -18,12 +19,14 @@ class OffererDetails extends PureComponent {
   render() {
     const { offerer, venues } = this.props
     return (
-      <AppLayout
-        layoutConfig={{
-          backTo: { label: 'Accueil', path: `/accueil?structure=${offerer.id}` },
-          pageName: 'offerer',
-        }}
-      >
+      <div className="offerer-page">
+        <NavLink
+          className="back-button has-text-primary"
+          to={`/accueil?structure=${offerer.id}`}
+        >
+          <Icon svg="ico-back" />
+          {'Accueil'}
+        </NavLink>
         <PageTitle title="Détails de votre structure" />
         <Titles
           subtitle={offerer.name}
@@ -66,7 +69,7 @@ class OffererDetails extends PureComponent {
           offererId={offerer.id}
           venues={venues}
         />
-      </AppLayout>
+      </div>
     )
   }
 }

--- a/src/components/pages/Offerers/Offerer/Venue/VenueCreation/VenueCreation.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/VenueCreation/VenueCreation.jsx
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import { getCanSubmit, parseSubmitErrors } from 'react-final-form-utils'
+import { NavLink } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import Icon from 'components/layout/Icon'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Titles from 'components/layout/Titles/Titles'
 
@@ -167,30 +168,30 @@ class VenueCreation extends PureComponent {
     const showForm = typeof offerer !== 'undefined'
 
     return (
-      <AppLayout
-        layoutConfig={{
-          backTo: { label: 'Accueil', path: `/accueil?structure=${offererId}` },
-          pageName: 'venue',
-        }}
-      >
-        <>
-          <PageTitle title="Créer un lieu" />
-          <Titles title="Lieu" />
-          <p className="advice">
-            {'Ajoutez un lieu où accéder à vos offres.'}
-          </p>
+      <div className="venue-page">
+        <NavLink
+          className="back-button has-text-primary"
+          to={`/accueil?structure=${offererId}`}
+        >
+          <Icon svg="ico-back" />
+          {'Accueil'}
+        </NavLink>
+        <PageTitle title="Créer un lieu" />
+        <Titles title="Lieu" />
+        <p className="advice">
+          {'Ajoutez un lieu où accéder à vos offres.'}
+        </p>
 
-          {showForm && (
-            <Form
-              decorators={decorators}
-              initialValues={formInitialValues}
-              name="venue"
-              onSubmit={this.handleOnFormSubmit}
-              render={this.onHandleRender}
-            />
-          )}
-        </>
-      </AppLayout>
+        {showForm && (
+          <Form
+            decorators={decorators}
+            initialValues={formInitialValues}
+            name="venue"
+            onSubmit={this.handleOnFormSubmit}
+            render={this.onHandleRender}
+          />
+        )}
+      </div>
     )
   }
 }

--- a/src/components/pages/Offerers/Offerer/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/VenueCreation/__specs__/VenueCreation.spec.jsx
@@ -96,17 +96,6 @@ describe('src | components | pages | Venue', () => {
         const title = wrapper.find({ children: 'Ajoutez un lieu où accéder à vos offres.' })
         expect(title).toHaveLength(1)
       })
-
-      it('should build the proper backTo link', () => {
-        // when
-        const wrapper = shallow(<VenueCreation {...props} />)
-
-        // then
-        expect(wrapper.prop('layoutConfig').backTo).toStrictEqual({
-          label: 'Accueil',
-          path: '/accueil?structure=APEQ',
-        })
-      })
     })
 
     describe('when editing', () => {

--- a/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueEdition.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueEdition.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
 import { getCanSubmit, parseSubmitErrors } from 'react-final-form-utils'
-import { Link } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import Icon from 'components/layout/Icon'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Titles from 'components/layout/Titles/Titles'
 import { ReactComponent as AddOfferSvg } from 'icons/ico-plus.svg'
@@ -188,12 +188,14 @@ class VenueEdition extends PureComponent {
     )
 
     return (
-      <AppLayout
-        layoutConfig={{
-          backTo: { label: 'Accueil', path: `/accueil?structure=${offererId}` },
-          pageName: 'venue',
-        }}
-      >
+      <div className="venue-page">
+        <NavLink
+          className="back-button has-text-primary"
+          to={`/accueil?structure=${offererId}`}
+        >
+          <Icon svg="ico-back" />
+          {'Accueil'}
+        </NavLink>
         <PageTitle title={pageTitle} />
         <Titles
           action={actionLink}
@@ -212,7 +214,7 @@ class VenueEdition extends PureComponent {
             render={this.onHandleRender}
           />
         )}
-      </AppLayout>
+      </div>
     )
   }
 }

--- a/src/components/pages/Offerers/OffererCreation/OffererCreation.jsx
+++ b/src/components/pages/Offerers/OffererCreation/OffererCreation.jsx
@@ -2,8 +2,9 @@ import createDecorator from 'final-form-calculate'
 import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { Form } from 'react-final-form'
+import { NavLink } from 'react-router-dom'
 
-import AppLayout from 'app/AppLayout'
+import Icon from 'components/layout/Icon'
 import PageTitle from 'components/layout/PageTitle/PageTitle'
 import Titles from 'components/layout/Titles/Titles'
 import { bindAddressAndDesignationFromSiren } from 'repository/siren/bindSirenFieldToDesignation'
@@ -41,12 +42,14 @@ class OffererCreation extends PureComponent {
 
   render() {
     return (
-      <AppLayout
-        layoutConfig={{
-          backTo: { label: 'Accueil', path: '/accueil' },
-          pageName: 'offerer',
-        }}
-      >
+      <div className="offerer-page">
+        <NavLink
+          className="back-button has-text-primary"
+          to="/accueil"
+        >
+          <Icon svg="ico-back" />
+          {'Accueil'}
+        </NavLink>
         <PageTitle title="Créer une structure" />
         <Titles title="Structure" />
 
@@ -56,7 +59,7 @@ class OffererCreation extends PureComponent {
           decorators={this.createDecorators()}
           onSubmit={this.handleSubmit}
         />
-      </AppLayout>
+      </div>
     )
   }
 }

--- a/src/components/pages/Offerers/OfferersLayout.jsx
+++ b/src/components/pages/Offerers/OfferersLayout.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route, Switch, useRouteMatch } from 'react-router-dom'
 
 import NotFound from 'components/pages/Errors/NotFound/NotFound'
 
@@ -8,7 +8,9 @@ import OfferersContainer from './List/OfferersContainer'
 import OffererDetailsLayout from './Offerer/OffererDetailsLayout'
 import OffererCreationContainer from './OffererCreation/OffererCreationContainer'
 
-const OfferersLayout = ({ match }) => {
+const OfferersLayout = () => {
+  const match = useRouteMatch()
+
   return (
     <Switch>
       <Route

--- a/src/styles/components/pages/Offerer/_Offerer.scss
+++ b/src/styles/components/pages/Offerer/_Offerer.scss
@@ -1,4 +1,6 @@
 .offerer-page {
+  padding-top: rem(50px);
+
   .op-teaser {
     margin-bottom: rem(24px);
   }

--- a/src/styles/components/pages/Venue/_Venue.scss
+++ b/src/styles/components/pages/Venue/_Venue.scss
@@ -1,4 +1,6 @@
 .venue-page {
+  padding-top: rem(50px);
+
   .col-66 {
     $size: 65.5%;
 

--- a/src/styles/global/_page.scss
+++ b/src/styles/global/_page.scss
@@ -79,7 +79,7 @@ main {
         position: relative;
 
         &.with-padding {
-          padding-top: 4.625rem;
+          padding-top: rem(74px);
         }
 
         .back-button {

--- a/src/utils/routes_map.jsx
+++ b/src/utils/routes_map.jsx
@@ -72,12 +72,6 @@ export const routesWithMain = [
     },
   },
   {
-    component: OfferersLayout,
-    exact: false,
-    path: '/structures',
-    title: 'Structures',
-  },
-  {
     component: ReimbursementsContainer,
     exact: true,
     path: '/remboursements',
@@ -157,6 +151,12 @@ const routes = [
         pageName: 'sign-in',
       },
     },
+  },
+  {
+    component: OfferersLayout,
+    exact: false,
+    path: '/structures',
+    title: 'Structures',
   },
   {
     component: OfferLayoutContainer,


### PR DESCRIPTION
Pour la nouvelles version de venue, nous avons besoin d'afficher une route enfant dans le layout du container parent.
Pour cela, il nous faut migrer les routes Offerers au nouveaux system de route, là ou AppLayout est directement rendu depuis `src/Root.js`