### PR TITLE
(PC-9225) Fix errors display on thing offers stocks page

### DIFF
--- a/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
+++ b/src/components/pages/Offers/Offer/Stocks/ThingStocks.jsx
@@ -256,7 +256,7 @@ const ThingStocks = ({
             {inCreateMode ? (
               <StockItemContainer
                 departmentCode={offer.venue.departementCode}
-                errors={formErrors[stock.key]}
+                errors={formErrors}
                 initialStock={stock}
                 isDigital={offer.isDigital}
                 isEvent={false}
@@ -269,7 +269,7 @@ const ThingStocks = ({
             ) : (
               <StockItemContainer
                 departmentCode={offer.venue.departementCode}
-                errors={formErrors[stock.key]}
+                errors={formErrors}
                 initialStock={stock}
                 isDigital={offer.isDigital}
                 isDisabled={isDisabled}

--- a/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
+++ b/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
@@ -2241,6 +2241,8 @@ describe('stocks page', () => {
           'Une ou plusieurs erreurs sont présentes dans le formulaire.'
         )
         expect(errorMessage).toBeInTheDocument()
+        expect(screen.getByLabelText('Prix')).toHaveClass('error')
+        expect(screen.getByLabelText('Quantité')).toHaveClass('error')
         expect(pcapi.bulkCreateOrEditStock).toHaveBeenCalledTimes(0)
       })
 
@@ -2485,6 +2487,8 @@ describe('stocks page', () => {
           'Une ou plusieurs erreurs sont présentes dans le formulaire.'
         )
         expect(errorMessage).toBeInTheDocument()
+        expect(screen.getByLabelText('Prix')).toHaveClass('error')
+        expect(screen.getByLabelText('Quantité')).toHaveClass('error')
         expect(pcapi.bulkCreateOrEditStock).toHaveBeenCalledTimes(0)
       })
 


### PR DESCRIPTION
Je n'ai pas pour habitude de tester les classnames, mais comme la non-apparition des bordures rouges sur les champs d'input en erreur a été remonté par le support, je me suis dit que c'était un cas métier à tester. 
Je n'ai pas trouvé meilleur moyen que la classname, mais le nom est suffisament générique pour que ce soit acceptable je trouve.