### PR TITLE
(PC-5091): make isbn field required on offer creation and update InputError to display CGU link

### DIFF
--- a/src/components/layout/inputs/DurationInput/DurationInput.jsx
+++ b/src/components/layout/inputs/DurationInput/DurationInput.jsx
@@ -78,10 +78,9 @@ const DurationInput = ({
         />
       </span>
       {error && (
-        <InputError
-          message={error}
-          name={name}
-        />
+        <InputError name={name}>
+          {error}
+        </InputError>
       )}
     </label>
   )

--- a/src/components/layout/inputs/Errors/InputError.jsx
+++ b/src/components/layout/inputs/Errors/InputError.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 import Icon from '../../Icon'
 
-const InputError = ({ name, message }) => {
+const InputError = ({ children, name }) => {
   const inputErrorExtraProps = name
     ? {
         'data-testid': `input-error-field-${name}`,
@@ -19,7 +19,7 @@ const InputError = ({ name, message }) => {
         svg="ico-notification-error-red"
       />
       <pre>
-        {message}
+        {children}
       </pre>
     </span>
   )
@@ -30,7 +30,7 @@ InputError.defaultProps = {
 }
 
 InputError.propTypes = {
-  message: PropTypes.string.isRequired,
+  children: PropTypes.shape().isRequired,
   name: PropTypes.string,
 }
 

--- a/src/components/layout/inputs/Select.jsx
+++ b/src/components/layout/inputs/Select.jsx
@@ -74,10 +74,9 @@ const Select = ({
       ))}
     </select>
     {error && (
-      <InputError
-        message={error}
-        name={name}
-      />
+      <InputError name={name}>
+        {error}
+      </InputError>
     )}
   </div>
 )

--- a/src/components/layout/inputs/TextInput/TextInput.jsx
+++ b/src/components/layout/inputs/TextInput/TextInput.jsx
@@ -45,10 +45,9 @@ const TextInput = ({
       value={value}
     />
     {error && (
-      <InputError
-        message={error}
-        name={name}
-      />
+      <InputError name={name}>
+        {error}
+      </InputError>
     )}
     {countCharacters && (
       <span className="it-character-count">

--- a/src/components/layout/inputs/TextInputWithIcon/TextInputWithIcon.jsx
+++ b/src/components/layout/inputs/TextInputWithIcon/TextInputWithIcon.jsx
@@ -49,7 +49,11 @@ const TextInputWithIcon = ({
         />
       </button>
     </div>
-    {error && <InputError message={error} />}
+    {error && (
+      <InputError>
+        {error}
+      </InputError>
+    )}
   </label>
 )
 

--- a/src/components/layout/inputs/TextareaInput.jsx
+++ b/src/components/layout/inputs/TextareaInput.jsx
@@ -45,10 +45,9 @@ const TextareaInput = ({
         value={textareaValue}
       />
       {error && (
-        <InputError
-          message={error}
-          name={name}
-        />
+        <InputError name={name}>
+          {error}
+        </InputError>
       )}
       {countCharacters && (
         <span className="it-character-count">

--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -31,6 +31,7 @@ import OfferRefundWarning from 'components/pages/Offers/Offer/OfferDetails/Offer
 import WithdrawalReminder from 'components/pages/Offers/Offer/OfferDetails/OfferForm/Messages/WithdrawalReminder'
 import TypeTreeSelects from 'components/pages/Offers/Offer/OfferDetails/OfferForm/TypeTreeSelects'
 import SynchronizedProviderInformation from 'components/pages/Offers/Offer/OfferDetails/SynchronizedProviderInformation'
+import { CGU_URL } from 'utils/config'
 import { doesUserPreferReducedMotion } from 'utils/windowMatchMedia'
 
 const getOfferConditionalFields = ({
@@ -412,6 +413,32 @@ const OfferForm = ({
     return fieldName in formErrors ? formErrors[fieldName] : null
   }
 
+  const getIsbnErrorMessage = () => {
+    const isbnErrorMessage = getErrorMessage('isbn')
+    if (
+      isbnErrorMessage &&
+      isbnErrorMessage.includes('Ce produit n’est pas éligible au pass Culture.')
+    ) {
+      return (
+        <>
+          {isbnErrorMessage}
+          <b>
+            {' Veuillez consulter nos'}
+            <a
+              href={CGU_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+              title={"Consulter les Conditions Générales d'Utilisation"}
+            >
+              {' conditions générales d’utilisation'}
+            </a>
+          </b>
+        </>
+      )
+    }
+    return isbnErrorMessage
+  }
+
   const isTypeOfflineButOnlyVirtualVenues = offerType?.offlineOnly && areAllVenuesVirtual
 
   if (isLoading) {
@@ -552,10 +579,11 @@ const OfferForm = ({
               <div className="form-row">
                 <TextInput
                   disabled={readOnlyFields.includes('isbn')}
-                  error={getErrorMessage('isbn')}
+                  error={getIsbnErrorMessage()}
                   label="ISBN"
                   name="isbn"
                   onChange={handleSingleFormUpdate}
+                  required
                   subLabel={!MANDATORY_FIELDS.includes('isbn') ? 'Optionnel' : ''}
                   type="text"
                   value={formValues.isbn}
@@ -755,7 +783,7 @@ const OfferForm = ({
 
             {Boolean(getErrorMessage('disabilityCompliant')) && (
               <InputError>
-                {"Vous devez cocher l'une des options ci-dessus"}
+                {'Vous devez cocher l’une des options ci-dessus'}
               </InputError>
             )}
           </section>

--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -754,7 +754,9 @@ const OfferForm = ({
             />
 
             {Boolean(getErrorMessage('disabilityCompliant')) && (
-              <InputError message="Vous devez cocher l'une des options ci-dessus" />
+              <InputError>
+                {"Vous devez cocher l'une des options ci-dessus"}
+              </InputError>
             )}
           </section>
 

--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/_constants.js
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/_constants.js
@@ -64,7 +64,7 @@ export const EXTRA_DATA_FIELDS = [
   'stageDirector',
   'visa',
 ]
-export const MANDATORY_FIELDS = ['name', 'venueId', 'offererId', 'url', 'bookingEmail']
+export const MANDATORY_FIELDS = ['name', 'venueId', 'offererId', 'url', 'bookingEmail', 'isbn']
 
 export const SYNCHRONIZED_OFFER_EDITABLE_FIELDS = {
   ALL_PROVIDERS: [

--- a/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
@@ -86,6 +86,14 @@ describe('offerDetails - Edition', () => {
         type: 'Thing',
         value: 'ThingType.LIVRE_EDITION',
       },
+      {
+        conditionalFields: ['author'],
+        offlineOnly: false,
+        onlineOnly: true,
+        proLabel: 'Livres audio numériques',
+        type: 'Thing',
+        value: 'ThingType.LIVRE_AUDIO',
+      },
     ]
     venueManagingOfferer = {
       id: 'BA',
@@ -111,6 +119,9 @@ describe('offerDetails - Edition', () => {
       description: 'My edited description',
       withdrawalDetails: 'My edited withdrawal details',
       status: 'SOLD_OUT',
+      extraData: {
+        isbn: '1234567890123',
+      },
     }
     props = {
       setShowThumbnailForm: jest.fn(),
@@ -198,7 +209,7 @@ describe('offerDetails - Edition', () => {
           )
           expect(errorNotification).toBeInTheDocument()
           let accessibilityErrorNotification = await screen.findByText(
-            "Vous devez cocher l'une des options ci-dessus"
+            'Vous devez cocher l’une des options ci-dessus'
           )
           expect(accessibilityErrorNotification).toBeInTheDocument()
           expect(pcapi.updateOffer).not.toHaveBeenCalled()
@@ -214,7 +225,7 @@ describe('offerDetails - Edition', () => {
 
           // Then
           accessibilityErrorNotification = await screen.queryByText(
-            "Vous devez cocher l'une des options ci-dessus"
+            'Vous devez cocher l’une des options ci-dessus'
           )
           expect(accessibilityErrorNotification).toBeNull()
         })
@@ -1302,7 +1313,9 @@ describe('offerDetails - Edition', () => {
         venue: editedOfferVenue,
         withdrawalDetails: 'Offer withdrawal details',
         bookingEmail: 'booking@example.net',
-        extraData: null,
+        extraData: {
+          isbn: '1234567890123',
+        },
         audioDisabilityCompliant: false,
         visualDisabilityCompliant: true,
         motorDisabilityCompliant: false,
@@ -1336,7 +1349,9 @@ describe('offerDetails - Edition', () => {
         venue: editedOfferVenue,
         withdrawalDetails: 'Offer withdrawal details',
         bookingEmail: 'booking@example.net',
-        extraData: null,
+        extraData: {
+          isbn: '1234567890123',
+        },
         audioDisabilityCompliant: false,
         visualDisabilityCompliant: true,
         motorDisabilityCompliant: false,
@@ -1456,7 +1471,7 @@ describe('offerDetails - Edition', () => {
       const editedOffer = {
         id: 'ABC12',
         name: 'My edited offer',
-        type: 'ThingType.LIVRE_EDITION',
+        type: 'ThingType.LIVRE_AUDIO',
         description: 'Offer description',
         venueId: editedOfferVenue.id,
         venue: editedOfferVenue,
@@ -1464,7 +1479,6 @@ describe('offerDetails - Edition', () => {
         bookingEmail: 'booking@example.net',
         extraData: {
           author: 'Mon auteur',
-          isbn: '123456789',
         },
         audioDisabilityCompliant: false,
         visualDisabilityCompliant: true,
@@ -1476,7 +1490,7 @@ describe('offerDetails - Edition', () => {
       await renderOffers(props, store)
 
       // When
-      await setOfferValues({ author: DEFAULT_FORM_VALUES.author, isbn: DEFAULT_FORM_VALUES.isbn })
+      await setOfferValues({ author: DEFAULT_FORM_VALUES.author })
 
       // Then
       userEvent.click(screen.getByText('Enregistrer'))
@@ -1536,7 +1550,9 @@ describe('offerDetails - Edition', () => {
         venue: editedOfferVenue,
         withdrawalDetails: 'Offer withdrawal details',
         bookingEmail: 'booking@example.net',
-        extraData: null,
+        extraData: {
+          isbn: '1234567890123',
+        },
         audioDisabilityCompliant: false,
         mentalDisabilityCompliant: false,
         motorDisabilityCompliant: false,
@@ -1601,7 +1617,9 @@ describe('offerDetails - Edition', () => {
         venue: editedOfferVenue,
         withdrawalDetails: 'Offer withdrawal details',
         bookingEmail: 'booking@example.net',
-        extraData: null,
+        extraData: {
+          isbn: '1234567890123',
+        },
         status: 'ACTIVE',
       }
       pcapi.loadOffer.mockResolvedValue(editedOffer)

--- a/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
+++ b/src/components/pages/Signup/SignupForm/__specs__/SignupForm.spec.jsx
@@ -281,7 +281,7 @@ describe('src | components | pages | Signup | SignupForm', () => {
       )
 
       // then
-      const error = wrapper.find({ children: 'erreur sur le mail' })
+      const error = wrapper.find({ children: 'erreur sur le mail' }).hostNodes()
       expect(error).toHaveLength(1)
     })
 


### PR DESCRIPTION
# Objectif
Importer les informations d'un livre depuis un ISBN13 lors de la création d'offre.
Avoir qu'un seul product pour un isbn.

# Implémentation
Rendre le champs isbn obligatoire pour la création d'offre de type LIVRE_EDITION.
~~Modification du composant `<InputError/>` pour afficher un lien vers GCU en cas de message d'erreur de non-éligibilité d'un produit.~~


PR [back](https://github.com/pass-culture/pass-culture-api/pull/2595)

-----
Update
Modifier le composant `<InputError/>` pour prendre la prop `children` à la place du `message` pour pouvoir afficher des liens (premier commit)