### PR TITLE
(PC-9250) offerers: Remove mentions of `Provider.requireProviderIdentifier`

### DIFF
--- a/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
@@ -17,7 +17,6 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
   const [providers, setProviders] = useState([])
   const [venueProviders, setVenueProviders] = useState([])
   const [isAllocineProviderSelected, setIsAllocineProviderSelected] = useState(false)
-  const [providerIdentifierIsRequired, setProviderIdentifierIsRequired] = useState(true)
 
   useEffect(() => {
     pcapi.loadProviders(venue.id).then(providers => setProviders(providers))
@@ -37,7 +36,6 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
       const selectedProviderId = event.target.value
       const selectedProvider = providers.find(provider => provider.id === selectedProviderId)
       setIsAllocineProviderSelected(false)
-      setProviderIdentifierIsRequired(selectedProvider?.requireProviderIdentifier)
       setSelectedProviderId(selectedProviderId)
 
       if (isAllocineProvider(selectedProvider)) {
@@ -108,7 +106,6 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
                 createVenueProvider={createVenueProvider}
                 providerId={selectedProviderId}
                 venueId={venue.id}
-                venueIdAtOfferProviderIsRequired={providerIdentifierIsRequired}
               />
             ) : (
               <StocksProviderForm

--- a/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/VenueEdition/VenueProvidersManager/__specs__/VenueProvidersManager.spec.jsx
@@ -45,8 +45,8 @@ describe('src | VenueProvidersManager', () => {
     }
 
     providers = [
-      { id: 'providerId1', requireProviderIdentifier: true, name: 'Cinema provider' },
-      { id: 'providerId2', requireProviderIdentifier: true, name: 'Movies provider' },
+      { id: 'providerId1', name: 'Cinema provider' },
+      { id: 'providerId2', name: 'Movies provider' },
     ]
     venueProviders = []
     pcapi.loadProviders.mockResolvedValue(providers)


### PR DESCRIPTION
This field is not used anymore and will be removed from the backend.
As far as I can tell, the `AllocineProviderForm` component does not
use the `venueIdAtOfferProviderIsRequired` property since 430f27e1cf63b90aa6bec4d07a7978fb7da5ce6a.

---

PR liée côté backend : pass-culture/pass-culture-api/pull/2604