### PR TITLE
(PC-9472): change date format in one test to make it locale and not utc

### DIFF
--- a/src/components/pages/Bookings/__specs__/BookingsRecap.spec.jsx
+++ b/src/components/pages/Bookings/__specs__/BookingsRecap.spec.jsx
@@ -335,7 +335,7 @@ describe('components | BookingsRecap | Pro user', () => {
     // Then
     await screen.findAllByText(bookingRecap.stock.offer_name)
     expect(getNthCallNthArg(loadFilteredBookingsRecap, 1).eventDate).toStrictEqual(
-      new Date('2020-06-08T00:00:00.000Z')
+      new Date(2020, 5, 8)
     )
   })
 


### PR DESCRIPTION
Actuellement dans un test de [bookingsRecap](https://github.com/pass-culture/pass-culture-pro/blob/7afc0a2696fa3d404718d83f1886674ed7f1042b/src/components/pages/Bookings/__specs__/BookingsRecap.spec.jsx#L319) nous filtrons sur le 8 du mois en cours pour l'eventDate.

Nous faisons ensuite une assertion sur l'argument de la fonction `loadFilteredBookingsRecap` : 
```
expect(getNthCallNthArg(loadFilteredBookingsRecap, 1).eventDate).toStrictEqual(
      new Date('2020-06-08T00:00:00.000Z')
    )
```

Il semblerait que le système fasse une conversion de la date sélectionnée (le 8/6/2020) en UTC avant de l'envoyer en argument dans la fonction.

```
Error: expect(received).toStrictEqual(expected) // deep equality

Expected: 2020-06-08T00:00:00.000Z
Received: 2020-06-07T22:00:00.000Z
```

Du coup je pense qu'il y a deux solutions:
- Soit changer ma propre configuration jest pour la mettre en utc (mais chaque nouveau doit le faire + ça serait bien de tester que cela fonctionne quand l'utilisateur n'a pas sa machine en utc)
- Soit j'utilise `new Date(2020, 5 , 8)` qui ne présuppose pas que mon système soit en UTC (contrairement au '2020-06-08T00:00:00.000Z' dont le Z "force" l'utc)

J'ai utilisé la 2e solution mais je suis preneur de vos retours, d'autant plus que d'autres tests dans le même fichier, avec le format UTC, ne cassent pas 🤔

Merci d'avance