### PR TITLE
[PC-9830] Desk: fix token validation

### DIFF
--- a/src/components/layout/inputs/TextInput/TextInput.jsx
+++ b/src/components/layout/inputs/TextInput/TextInput.jsx
@@ -13,6 +13,7 @@ const TextInput = ({
   maxLength,
   name,
   onChange,
+  onKeyDown,
   placeholder,
   required,
   subLabel,
@@ -40,6 +41,7 @@ const TextInput = ({
       maxLength={maxLength}
       name={name}
       onChange={onChange}
+      onKeyDown={onKeyDown}
       placeholder={placeholder}
       ref={inputRef}
       required={required}
@@ -67,6 +69,7 @@ TextInput.defaultProps = {
   longDescription: null,
   maxLength: null,
   onChange: null,
+  onKeyDown: null,
   placeholder: '',
   required: false,
   subLabel: '',
@@ -84,6 +87,7 @@ TextInput.propTypes = {
   maxLength: PropTypes.number,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
+  onKeyDown: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   subLabel: PropTypes.string,

--- a/src/components/pages/Desk/Desk.jsx
+++ b/src/components/pages/Desk/Desk.jsx
@@ -52,11 +52,29 @@ class Desk extends Component {
     this.tokenInputRef.current.focus()
   }
 
-  validateToken = event => {
+  onChangeToken = event => {
+    this.validateToken(event.target.value)
+  }
+
+  /**
+   * When the input value is set from a codebar scanner it doesn't trigger the onChange event.
+   * We need to validate the token value directly from the input value when ENTER is press.
+   */
+  onKeyDownToken = event => {
+    const { token } = this.state
+    if (event.key.toUpperCase() === 'ENTER') {
+      const inputValue = event.target.value
+      if (inputValue && !token) {
+        this.validateToken(inputValue)
+      }
+    }
+  }
+
+  validateToken = incomingToken => {
     const { getBooking } = this.props
-    const inputValue = event.target.value.toUpperCase()
+    let token = incomingToken.toUpperCase()
     // QRCODE return a prefix that we want to ignore.
-    const token = inputValue.split(':').reverse()[0]
+    token = token.split(':').reverse()[0]
 
     const { canCheckTheToken, level, message } = this.getStatusFromToken(token)
     this.setState({
@@ -139,6 +157,7 @@ class Desk extends Component {
 
   registrationOfToken = token => event => {
     event.preventDefault()
+
     const { validateBooking } = this.props
 
     this.setState({
@@ -172,6 +191,7 @@ class Desk extends Component {
 
   invalidationOfToken = token => event => {
     event.preventDefault()
+
     const { invalidateBooking } = this.props
     this.setState({
       message: 'Invalidation en cours...',
@@ -217,7 +237,8 @@ class Desk extends Component {
             inputRef={this.tokenInputRef}
             label="Contremarque"
             name="token"
-            onChange={this.validateToken}
+            onChange={this.onChangeToken}
+            onKeyDown={this.onKeyDownToken}
             placeholder="ex : AZE123"
             type="text"
             value={token}


### PR DESCRIPTION
```
  When a user enter a token with a codebar scanner, it's set
programaticaly using input.value = '{codebar}'
This way to set the input value do not trigger onChange event.

Here, if the token value is empty we'll do the validation directly from
the input value.
```
============

jira: https://passculture.atlassian.net/browse/PC-9830

Je suppose que le problème vient de là, le code fonctionne sur tout les navigateur et je ne voit pas d'autre cas ou le "onChange" ne serait pas appelé.

Description de ce qui à été fait :
Au chargement de la page: 

![page_loaded](https://user-images.githubusercontent.com/139848/124288443-7794b380-db51-11eb-9b68-4af0125c7120.png)

On force la valeur de l'input `token` via un script javascript:

![token_set_from_script](https://user-images.githubusercontent.com/139848/124288447-782d4a00-db51-11eb-9a99-7888b399ea78.png)

Dans un cas d'utilisation normal (sans ouverture de la console comme dans mon test), l'input `token` à le focus.
On presse alors la touche 'ENTER'

![enter_press_on_focused_input](https://user-images.githubusercontent.com/139848/124288435-76638680-db51-11eb-8473-4504a79a064c.png)

Il faudra presser une 2em fois la touche 'ENTER' pour valider (ou invalider) la contremarque.

