### PR TITLE
[BSR] styles/mixins/_rem: fix sass warning

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -45,7 +45,8 @@
         "if",
         "include",
         "mixin",
-        "return"
+        "return",
+        "use"
       ]
     }],
     "order/properties-alphabetical-order": true

--- a/src/styles/mixins/_rem.scss
+++ b/src/styles/mixins/_rem.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 $rem-baseline: 16px !default;
 $rem-fallback: true !default;
 $rem-px-only: false !default;
@@ -22,6 +24,7 @@ $rem-px-only: false !default;
 }
 
 @mixin rem-baseline($zoom: 100%) {
+  /* stylelint-disable-next-line */
   font-size: $zoom / 16px * $rem-baseline;
 }
 
@@ -31,7 +34,7 @@ $rem-px-only: false !default;
 
   @each $value in $values {
     @if type-of($value) == 'number' and unit($value) == 'rem' and $to == 'px' {
-      $result: append($result, $value / 1rem * $rem-baseline, $separator);
+      $result: append($result, math.div($value, 1rem) * $rem-baseline, $separator);
     }
 
     @else if
@@ -41,7 +44,7 @@ $rem-px-only: false !default;
       'px' and
       $to ==
       'rem' {
-      $result: append($result, $value / $rem-baseline * 1rem, $separator);
+      $result: append($result, math.div($value, $rem-baseline) * 1rem, $separator);
     }
 
     @else if type-of($value) == 'list' {


### PR DESCRIPTION
Lorsque je lance pro en locale j'ai une erreurs stylelint:

```shell
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($value, $rem-baseline)

More info and automated migrator: https://sass-lang.com/d/slash-div

   ╷
44 │       $result: append($result, $value / $rem-baseline * 1rem, $separator);
   │                                ^^^^^^^^^^^^^^^^^^^^^^
   ╵
    src/styles/mixins/_rem.scss 44:32    rem-convert()
    src/styles/mixins/_rem.scss 68:13    rem()
    src/styles/mixins/_fonts.scss 43:14  body()
    src/styles/global/_form.scss 10:3    @import
    src/styles/global/index.scss 4:9     @import
    src/styles/index.scss 7:9            root stylesheet
```