### PR TITLE
[BSR] Initialize offers.categories store entry

### DIFF
--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferCreation.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferCreation.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
 
 import Spinner from 'components/layout/Spinner'
 import { computeOffersUrl } from 'components/pages/Offers/utils/computeOffersUrl'
@@ -26,10 +27,18 @@ const OfferCreation = ({
   const [displayedVenues, setDisplayedVenues] = useState([])
   const [selectedOfferer, setSelectedOfferer] = useState(initialValues.offererId)
 
+  const { categories } = useSelector(state => state.offers.categories)
+
   useEffect(() => setSelectedOfferer(initialValues.offererId), [initialValues.offererId])
 
   useEffect(() => {
     (async () => {
+      // On first load store.offers.categories is not set.
+      // in this case we want do display the spinner using isLoading === true.
+      if (categories === undefined) {
+        return
+      }
+
       if (isUserAdmin) {
         const offererResponse = await pcapi.getOfferer(initialValues.offererId)
 
@@ -57,7 +66,7 @@ const OfferCreation = ({
 
       setIsLoading(false)
     })()
-  }, [initialValues.offererId, isUserAdmin, initialValues])
+  }, [initialValues.offererId, isUserAdmin, initialValues, categories])
 
   const filterVenuesForPro = useCallback(() => {
     const venuesToDisplay = selectedOfferer


### PR DESCRIPTION
Il arrive lors du premier chargement que le composant de catégories utilise la variable avant que l'api ai répondu.

![ERRRU_PRO](https://user-images.githubusercontent.com/139848/126613340-195600cb-dec6-44d5-abbe-26bcdcb54006.png)

Edit: Lors de la création uniquement, le composant OfferCreation n'attend pas le chargement des categories avant de render OfferCategories.