### PR TITLE
(PC-8826): fix json parse error when service unavailable

### DIFF
--- a/src/repository/pcapi/__specs__/pcapiClient.spec.js
+++ b/src/repository/pcapi/__specs__/pcapiClient.spec.js
@@ -86,13 +86,10 @@ describe('pcapiClient', () => {
 
     it('should redirect to maintenance page when status is 503', async () => {
       // Given
-      fetch.mockResponse(JSON.stringify('Service Unavailable'), { status: 503 })
+      fetch.mockResponse('Service Unavailable', { status: 503 })
 
       // When
-      await expect(client.get('/bookings/pro')).rejects.toStrictEqual({
-        errors: 'Service Unavailable',
-        status: 503,
-      })
+      await expect(client.get('/bookings/pro')).rejects.toBeNull()
 
       // Then
       expect(setHrefSpy).toHaveBeenCalledWith(URL_FOR_MAINTENANCE)

--- a/src/repository/pcapi/pcapiClient.js
+++ b/src/repository/pcapi/pcapiClient.js
@@ -4,6 +4,7 @@ export const HTTP_STATUS = {
   FORBIDDEN: 403,
   SERVICE_UNAVAILABLE: 503,
 }
+const NOT_JSON_BODY_RESPONSE_STATUS = [HTTP_STATUS.NO_CONTENT, HTTP_STATUS.SERVICE_UNAVAILABLE]
 const GET_HTTP_METHOD = 'GET'
 const DELETE_HTTP_METHOD = 'DELETE'
 
@@ -25,7 +26,9 @@ const buildUrl = path => `${API_URL}${path}`
 
 const fetchWithErrorHandler = async (path, options) => {
   const response = await fetch(buildUrl(path), options)
-  const results = response.status !== HTTP_STATUS.NO_CONTENT ? await response.json() : null
+  const results = NOT_JSON_BODY_RESPONSE_STATUS.includes(response.status)
+    ? null
+    : await response.json()
   if (!response.ok) {
     if (response.status === HTTP_STATUS.SERVICE_UNAVAILABLE) {
       window.location.href = URL_FOR_MAINTENANCE


### PR DESCRIPTION
Dans le cas où l'api est indisponible, le serveur renvoie une erreur HTTP 503 et une response body sous forme d'une page html.
![image](https://user-images.githubusercontent.com/77629406/127003135-58a55417-ff24-4ea3-a2d4-1264ac2197f9.png)

Fix:
Ne pas parser le body response dans le cas de HTTP status 503.