### PR TITLE
(PC-10335) : add and configure eslint-plugin-testing-library

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     "plugin:import/errors",
     "plugin:jest/all",
     "plugin:pass-culture/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
+    "plugin:testing-library/react"
   ],
   "env": {
     "browser": true,
@@ -85,7 +86,11 @@
         "jest/require-top-level-describe": "off",
         "jest/no-done-callback": "off"
       }
-    }
+    },
+    {
+      "files": ["./src/**/__tests__/**/*.[jt]s?(x)", ".src/**/?(*.)+(spec|test).[jt]s?(x)"],
+      "extends": ["plugin:testing-library/react"]
+    },
   ],
   "settings": {
     "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "eslint-plugin-pass-culture": "./eslint-plugin-pass-culture",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-testing-library": "^3.9.2",
+    "eslint-plugin-testing-library": "^4.10.1",
     "eslint-webpack-plugin": "^2.1.0",
     "file-loader": "^6.2.0",
     "fs-extra": "^9.0.1",

--- a/src/components/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.jsx
@@ -81,7 +81,7 @@ describe('src | Offerer | ApiKey', () => {
     jest.spyOn(navigator.clipboard, 'writeText')
     generateFakeOffererApiKey('new-key')
     fireEvent.click(screen.getByText('Générer une clé API', { selector: 'button' }))
-    await waitFor(() => screen.getByText('Copier', { selector: 'button' }))
+    await screen.findByText('Copier', { selector: 'button' })
 
     // when
     fireEvent.click(screen.getByText('Copier', { selector: 'button' }))

--- a/src/components/pages/Offerers/Offerer/Venue/__specs__/VenueLayout.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/Venue/__specs__/VenueLayout.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/dom'
+import { fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act, render, screen } from '@testing-library/react'
 import React from 'react'

--- a/src/components/pages/Offers/Offer/__specs__/OfferLayout.spec.jsx
+++ b/src/components/pages/Offers/Offer/__specs__/OfferLayout.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent } from '@testing-library/dom'
+import { fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { act, render, screen, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4019,6 +4019,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json-schema@^7.0.7":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -4295,16 +4300,17 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/experimental-utils@^3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
-  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+"@typescript-eslint/experimental-utils@^4.24.0":
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.1.tgz#0af2b17b0296b60c6b207f11062119fa9c5a8994"
+  integrity sha512-kl6QG6qpzZthfd2bzPNSJB2YcZpNOrP6r9jueXupcZHnL74WiuSjaft7WSu17J9+ae9zTlk0KJMXPUj0daBxMw==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.29.1"
+    "@typescript-eslint/types" "4.29.1"
+    "@typescript-eslint/typescript-estree" "4.29.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^4.5.0":
   version "4.22.0"
@@ -4324,29 +4330,23 @@
     "@typescript-eslint/types" "4.22.0"
     "@typescript-eslint/visitor-keys" "4.22.0"
 
-"@typescript-eslint/types@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
-  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
+"@typescript-eslint/scope-manager@4.29.1":
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz#f25da25bc6512812efa2ce5ebd36619d68e61358"
+  integrity sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==
+  dependencies:
+    "@typescript-eslint/types" "4.29.1"
+    "@typescript-eslint/visitor-keys" "4.29.1"
 
 "@typescript-eslint/types@4.22.0":
   version "4.22.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
   integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
 
-"@typescript-eslint/typescript-estree@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
-  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
-  dependencies:
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/visitor-keys" "3.10.1"
-    debug "^4.1.1"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+"@typescript-eslint/types@4.29.1":
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.1.tgz#94cce6cf7cc83451df03339cda99d326be2feaf5"
+  integrity sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==
 
 "@typescript-eslint/typescript-estree@4.22.0":
   version "4.22.0"
@@ -4361,12 +4361,18 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
-  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
+"@typescript-eslint/typescript-estree@4.29.1":
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz#7b32a25ff8e51f2671ccc6b26cdbee3b1e6c5e7f"
+  integrity sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/types" "4.29.1"
+    "@typescript-eslint/visitor-keys" "4.29.1"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/visitor-keys@4.22.0":
   version "4.22.0"
@@ -4374,6 +4380,14 @@
   integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
   dependencies:
     "@typescript-eslint/types" "4.22.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.29.1":
+  version "4.29.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz#0615be8b55721f5e854f3ee99f1a714f2d093e5d"
+  integrity sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==
+  dependencies:
+    "@typescript-eslint/types" "4.29.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -8252,12 +8266,12 @@ eslint-plugin-react@^7.21.5:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.4"
 
-eslint-plugin-testing-library@^3.9.2:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz#609ec2b0369da7cf2e6d9edff5da153cc31d87bd"
-  integrity sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==
+eslint-plugin-testing-library@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-4.10.1.tgz#f1f2867697a4dbdf9b14f8f5f594435c72233960"
+  integrity sha512-pISDdbDBTAkd6nnAoMIMLsU91UBh6l3UX5n0FdUjGM0D92WLw+z/0WR4iptO06G2UhkwcTNl1r/K4huS3/gsXA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "^3.10.1"
+    "@typescript-eslint/experimental-utils" "^4.24.0"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8288,6 +8302,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -9487,6 +9508,18 @@ globby@^11.0.1, globby@^11.0.2:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.0.3:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -18098,7 +18131,7 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
-tsutils@^3.17.1:
+tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
résultat pour `npx eslint ./src/**/*.spec.*`

```
/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/layout/Banner/__specs__/Banner.spec.jsx
  47:40  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  66:40  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/layout/Banner/__specs__/InternalBanner.spec.jsx
  32:47  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  45:47  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/layout/Header/__specs__/Header.spec.jsx
  46:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  54:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/layout/RouteLeavingGuard/__specs__/RouteLeavingGuard.spec.jsx
  50:18  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  50:18  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Bookings/BookingsRecapTable/CellsFormatter/__specs__/BookingOfferCell.spec.jsx
  30:32  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  30:32  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  51:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  51:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  74:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  74:42  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Bookings/__specs__/BookingsRecap.spec.jsx
  378:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  378:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  411:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  411:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  441:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  441:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  471:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  471:82  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Desk/__specs__/Desk.spec.jsx
  162:33  warning  `queryByTextTrimHtml` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  164:34  warning  `queryByTextTrimHtml` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  166:33  warning  `queryByTextTrimHtml` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  168:34  warning  `queryByTextTrimHtml` query is sync so it does not need to be awaited  testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Home/Offerers/__specs__/OffererDetails.spec.jsx
  225:55  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  225:55  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  335:57  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  335:57  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  445:41  warning  `queryByAltText` query is sync so it does not need to be awaited         testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Home/Offerers/__specs__/OffererDetailsLegacy.spec.jsx
  193:55  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  193:55  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  285:57  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  285:57  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  371:41  warning  `queryByAltText` query is sync so it does not need to be awaited         testing-library/no-await-sync-query
  390:41  warning  `queryByAltText` query is sync so it does not need to be awaited         testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Home/__specs__/Homepage.spec.jsx
  188:31  warning  `queryByLabelText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offerers/Offerer/OffererDetails/ApiKey/__specs__/ApiKey.spec.jsx
  84:11  warning  Prefer `findByText` query over using `waitFor` + `getByText`  testing-library/prefer-find-by

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offerers/Offerer/Venue/__specs__/VenueLayout.spec.jsx
  1:1  warning  import from DOM Testing Library is restricted, import from @testing-library/react instead  testing-library/no-dom-import

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offerers/Offerer/VenueV1/fields/BankInformationFields/__specs__/BankInformation.spec.jsx
  205:29  warning  `queryByText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  206:29  warning  `queryByText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
   389:31  warning  `queryAllByText` query is sync so it does not need to be awaited         testing-library/no-await-sync-query
   405:31  warning  `queryAllByText` query is sync so it does not need to be awaited         testing-library/no-await-sync-query
  1324:56  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1324:56  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1768:7   warning  Promise returned from `waitFor` must be handled                          testing-library/await-async-utils

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
  211:57  warning  `queryByText` query is sync so it does not need to be awaited   testing-library/no-await-sync-query
  403:24  warning  `getByTitle` query is sync so it does not need to be awaited    testing-library/no-await-sync-query
  465:29  warning  `getAllByText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  473:29  warning  `getAllByText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query
  481:29  warning  `getAllByText` query is sync so it does not need to be awaited  testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/Stocks/ActivationCodesUploadDialog/__specs__/ActivationCodesUploadDialog.spec.jsx
  74:27  warning  `getByTestId` query is sync so it does not need to be awaited  testing-library/no-await-sync-query

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/Stocks/__specs__/Stocks.spec.jsx
   109:29  warning  `queryByRole` query is sync so it does not need to be awaited            testing-library/no-await-sync-query
   120:29  warning  `queryByText` query is sync so it does not need to be awaited            testing-library/no-await-sync-query
   121:29  warning  `queryByText` query is sync so it does not need to be awaited            testing-library/no-await-sync-query
   408:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   411:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   414:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   417:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   420:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   428:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   486:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   489:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   492:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   500:31  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1916:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1916:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2552:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2552:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2568:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2568:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2595:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2595:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2624:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2624:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2654:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2654:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2699:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2699:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2741:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2741:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2759:69  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2775:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2775:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2808:69  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2823:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2823:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2855:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2855:14  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2878:64  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  2915:69  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/__specs__/Breadcrumb.spec.jsx
   33:24  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   58:24  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  109:23  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offer/__specs__/OfferLayout.spec.jsx
  1:1  warning  import from DOM Testing Library is restricted, import from @testing-library/react instead  testing-library/no-dom-import

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offers/OfferItem/__specs__/OfferItem.spec.jsx
  261:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  261:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  274:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  274:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  289:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  289:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  309:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  309:60  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  322:50  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  333:50  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  344:50  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  355:50  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access

/Users/gael.boyenval/dev/pass-culture-main/pro/src/components/pages/Offers/Offers/__specs__/Offers.spec.jsx
   451:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   468:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   487:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   520:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   547:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   579:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   606:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   620:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
   634:38  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1296:27  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
  1308:23  warning  Avoid direct Node access. Prefer using the methods from Testing Library  testing-library/no-node-access
```