### PR TITLE
[PC-10374] prevent user from filling multiline title when creating/editing an offer

### DIFF
--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferForm.jsx
@@ -560,7 +560,7 @@ const OfferForm = ({
               </h3>
 
               <div className="form-row">
-                <TextareaInput
+                <TextInput
                   countCharacters
                   disabled={readOnlyFields.includes('name')}
                   error={getErrorMessage('name')}
@@ -569,7 +569,6 @@ const OfferForm = ({
                   name="name"
                   onChange={handleSingleFormUpdate}
                   required
-                  rows={1}
                   subLabel={!mandatoryFields.includes('name') ? 'Optionnel' : ''}
                   value={formValues.name}
                 />
@@ -597,7 +596,6 @@ const OfferForm = ({
                     name="speaker"
                     onChange={handleSingleFormUpdate}
                     subLabel={!mandatoryFields.includes('speaker') ? 'Optionnel' : ''}
-                    type="text"
                     value={formValues.speaker}
                   />
                 </div>

--- a/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
@@ -372,7 +372,8 @@ describe('offerDetails - Creation - pro user', () => {
           userEvent.type(titleInput, 'Mon joli titre')
 
           // then
-          expect(screen.getAllByText('Mon joli titre')).toHaveLength(2)
+          const offerPreview = screen.getByTestId('offer-preview-section')
+          expect(within(offerPreview).getByText('Mon joli titre')).toBeInTheDocument()
         })
 
         it('should display description when input is filled', async () => {
@@ -386,7 +387,8 @@ describe('offerDetails - Creation - pro user', () => {
           userEvent.type(descriptionInput, 'Ma jolie description')
 
           // then
-          expect(await screen.queryAllByText('Ma jolie description')).toHaveLength(2)
+          const offerPreview = screen.getByTestId('offer-preview-section')
+          expect(within(offerPreview).getByText('Ma jolie description')).toBeInTheDocument()
         })
 
         it('should display terms of withdrawal when input is filled', async () => {
@@ -402,7 +404,8 @@ describe('offerDetails - Creation - pro user', () => {
           userEvent.type(withdrawalInput, 'Mes jolies modalités')
 
           // then
-          expect(await screen.queryAllByText('Mes jolies modalités')).toHaveLength(2)
+          const offerPreview = screen.getByTestId('offer-preview-section')
+          expect(within(offerPreview).getByText('Mes jolies modalités')).toBeInTheDocument()
         })
 
         it("should display disabled 'isDuo' icone for offers that aren't event", async () => {

--- a/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferEdition.spec.jsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Provider } from 'react-redux'
@@ -208,7 +208,7 @@ describe('offerDetails - Edition', () => {
           userEvent.click(mentalDisabilityCompliantCheckbox)
 
           // Then
-          accessibilityErrorNotification = await screen.queryByText(
+          accessibilityErrorNotification = screen.queryByText(
             'Vous devez cocher l’une des options ci-dessus'
           )
           expect(accessibilityErrorNotification).toBeNull()
@@ -400,7 +400,7 @@ describe('offerDetails - Edition', () => {
 
         // Then
         expect(
-          await screen.getByTitle('Modifier l’image', { selector: 'button' })
+          screen.getByTitle('Modifier l’image', { selector: 'button' })
         ).toBeInTheDocument()
         expect(
           screen.queryByTitle('Fermer la modale', { selector: 'button' })
@@ -462,7 +462,8 @@ describe('offerDetails - Edition', () => {
         await renderOffers({}, store)
 
         // then
-        expect(await screen.getAllByText('My edited offer')).toHaveLength(2)
+        const offerPreview = screen.getByTestId('offer-preview-section')
+        expect(within(offerPreview).getByText(editedOffer.name)).toBeInTheDocument()
       })
 
       it('should display description', async () => {
@@ -470,7 +471,8 @@ describe('offerDetails - Edition', () => {
         await renderOffers({}, store)
 
         // then
-        expect(await screen.getAllByText('My edited description')).toHaveLength(2)
+        const offerPreview = screen.getByTestId('offer-preview-section')
+        expect(within(offerPreview).getByText(editedOffer.description)).toBeInTheDocument()
       })
 
       it('should display terms of withdrawal', async () => {
@@ -478,7 +480,8 @@ describe('offerDetails - Edition', () => {
         await renderOffers({}, store)
 
         // then
-        expect(await screen.getAllByText('My edited withdrawal details')).toHaveLength(2)
+        const offerPreview = screen.getByTestId('offer-preview-section')
+        expect(within(offerPreview).getByText(editedOffer.withdrawalDetails)).toBeInTheDocument()
       })
 
       describe('when fraud detection', () => {
@@ -1138,7 +1141,7 @@ describe('offerDetails - Edition', () => {
       fireEvent.click(await screen.findByText("Détail de l'offre"))
 
       // Then
-      expect(await getOfferInputForField('name')).toHaveTextContent(editValues.name)
+      expect(await getOfferInputForField('name')).toHaveValue(editValues.name)
 
       const expectedSubCategoryValue = categories.subcategories.find(
         subCat => subCat.id.toString() === editValues.subcategoryId


### PR DESCRIPTION
juste un `input` utilisé pour le titre d'une offre au lieu d'un `textarea`.

quelques impacts sur les tests dus au fait qu'on ne récupère pas le texte d'un input de la même manière que le texte d'un textarea.

quelques messages es-lint corrigé au sujet d'`await` inutiles. j'en ai ignorés plein d'autres qui nécessitent des refactorings (ce qui dépasse de loin mes compétences front)