### PR TITLE
(PC-10353): Reset token after validation or invalidation

### DIFF
--- a/src/components/pages/Desk/Desk.jsx
+++ b/src/components/pages/Desk/Desk.jsx
@@ -47,6 +47,19 @@ class Desk extends Component {
     return errorResponse.errors[errorKey]
   }
 
+  resetToken = () => {
+    this.setState(
+      {
+        token: '',
+        isUsedToken: false,
+        isDisabledButton: true,
+      },
+      () => {
+        this.resetTokenField()
+      }
+    )
+  }
+
   resetTokenField = () => {
     this.tokenInputRef.current.value = ''
     this.tokenInputRef.current.focus()
@@ -152,15 +165,7 @@ class Desk extends Component {
           message: 'Contremarque validée !',
         })
         trackValidateBookingSuccess(token)
-      })
-      .then(() => {
-        this.setState({
-          isDisabledButton: false,
-          isUsedToken: true,
-        })
-      })
-      .then(() => {
-        this.resetTokenField()
+        this.resetToken()
       })
       .catch(error => {
         this.setState({
@@ -182,15 +187,7 @@ class Desk extends Component {
         this.setState({
           message: 'Contremarque invalidée !',
         })
-      })
-      .then(() => {
-        this.setState({
-          isUsedToken: false,
-          isDisabledButton: false,
-        })
-      })
-      .then(() => {
-        this.resetTokenField()
+        this.resetToken()
       })
       .catch(error => {
         this.setState({

--- a/src/components/pages/Desk/__specs__/Desk.spec.jsx
+++ b/src/components/pages/Desk/__specs__/Desk.spec.jsx
@@ -214,19 +214,19 @@ describe('src | components | Desk', () => {
       renderDesk(props)
       const tokenInput = screen.getByLabelText('Contremarque')
       const submitButton = screen.getByRole('button', { name: 'Valider la contremarque' })
+
+      expect(submitButton).toBeDisabled()
       await waitFor(() => fireEvent.change(tokenInput, { target: { value: 'MEFA01' } }))
 
       // when
+      expect(submitButton).toBeEnabled()
       fireEvent.click(submitButton)
 
       // then
       expect(screen.getByText('Validation en cours...')).toBeInTheDocument()
       const responseFromApi = await screen.findByText('Contremarque validée !')
       expect(responseFromApi).toBeInTheDocument()
-      const newSubmitButton = await screen.findByRole('button', {
-        name: 'Invalider la contremarque',
-      })
-      expect(newSubmitButton).toBeEnabled()
+      expect(submitButton).toBeDisabled()
     })
 
     it('should display a message when booking is invalidated', async () => {
@@ -238,18 +238,23 @@ describe('src | components | Desk', () => {
       jest.spyOn(props, 'invalidateBooking').mockResolvedValue()
       renderDesk(props)
       const tokenInput = screen.getByLabelText('Contremarque')
+
+      const validateTokenButton = screen.getByRole('button', { name: 'Valider la contremarque' })
+      expect(validateTokenButton).toBeDisabled()
+
       fireEvent.change(tokenInput, { target: { value: 'MEFA01' } })
-      const submitButton = await screen.findByRole('button', { name: 'Invalider la contremarque' })
+      const invalidateTokenButton = await screen.findByRole('button', { name: 'Invalider la contremarque' })
+
 
       // when
-      fireEvent.click(submitButton)
+      expect(invalidateTokenButton).toBeEnabled()
+      fireEvent.click(invalidateTokenButton)
 
       // then
       expect(screen.getByText('Invalidation en cours...')).toBeInTheDocument()
       const responseFromApi = await screen.findByText('Contremarque invalidée !')
       expect(responseFromApi).toBeInTheDocument()
-      const newSubmitButton = await screen.findByRole('button', { name: 'Valider la contremarque' })
-      expect(newSubmitButton).toBeEnabled()
+      expect(validateTokenButton).toBeDisabled()
     })
 
     it('should display an error message when the booking validation has failed', async () => {


### PR DESCRIPTION
**Objectif:** Désactiver le bouton valider ou invalider sur la page guichet après une validation ou invalidation pour ne pas permettre aux utilisateurs de les spammer. 