### PR TITLE
(PC-10419) : add a test end-to-end test cafe for booking validation route when booking is educational

### DIFF
--- a/testcafe/10_desk.js
+++ b/testcafe/10_desk.js
@@ -29,3 +29,28 @@ test('je peux valider une contremarque', async t => {
     .expect(state.innerText)
     .eql('Contremarque validée !')
 })
+
+test('je peux valider une contremarque lorsque l’offre est educationnelle et validée par le chef d’établissement', async t => {
+  const { booking, user } = await fetchSandbox(
+    'pro_10_desk',
+    'get_existing_pro_validated_user_with_validated_offerer_with_validated_user_offerer_with_eac_offer_with_stock_with_not_used_booking_USED_BY_INSTITUTE'
+  )
+
+  const pageTitleHeader = Selector('h1')
+  const deskLink = Selector('a').withText('Guichet')
+  const codeInput = Selector('input[type="text"]')
+  const state = Selector('.desk-message')
+  const registerButton = Selector('button').withText('Valider la contremarque')
+
+  await t
+    .useRole(createUserRole(user))
+    .click(deskLink)
+    .expect(pageTitleHeader.innerText)
+    .eql('Guichet')
+    .typeText(codeInput, booking.token)
+    .expect(state.innerText)
+    .eql('Coupon vérifié, cliquez sur "Valider" pour enregistrer')
+    .click(registerButton)
+    .expect(state.innerText)
+    .eql('Contremarque validée !')
+})


### PR DESCRIPTION
- Les réservations eac (educationnelles) ont quelques spécificités (pas de `User` par ex.)
- Nous souhaitions donc ajouter un test e2e sur la validation d'une contremarque pour une réservation eac