### PR TITLE
(PC-8558): Allow allocine provider edition

### DIFF
--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
@@ -6,17 +6,22 @@
 */
 
 import PropTypes from 'prop-types'
-import React, { useCallback, useState } from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
 import { Form } from 'react-final-form'
 import { getCanSubmit } from 'react-final-form-utils'
+import ReactTooltip from "react-tooltip"
 
 import CheckboxField from 'components/layout/form/fields/CheckboxField'
 import NumberField from 'components/layout/form/fields/NumberField'
 import Icon from 'components/layout/Icon'
 import Insert from 'components/layout/Insert/Insert'
 
-const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
+const AllocineProviderForm = ({ saveVenueProvider, providerId, venueId, isCreatedEntity, initialValues, onCancel}) => {
   const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    ReactTooltip.rebuild()
+  }, [])
 
   const handleSubmit = useCallback(
     formValues => {
@@ -32,9 +37,9 @@ const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
 
       setIsLoading(true)
 
-      createVenueProvider(payload)
+      saveVenueProvider(payload)
     },
-    [createVenueProvider, providerId, venueId]
+    [saveVenueProvider, providerId, venueId]
   )
 
   const required = useCallback(value => {
@@ -44,7 +49,6 @@ const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
   const renderForm = useCallback(
     formProps => {
       const canSubmit = getCanSubmit(formProps)
-
       return (
         <form>
           {!isLoading && (
@@ -52,7 +56,7 @@ const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
               <div className="apf-price-section">
                 <div className="price-section-label">
                   <label htmlFor="price">
-                    Prix de vente/place 
+                    Prix de vente/place
                     {' '}
                     <span className="field-asterisk">
                       *
@@ -93,7 +97,7 @@ const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
               </div>
               <div className="apf-is-duo-section">
                 <CheckboxField
-                  checked
+                  checked={formProps.initialValues?.isDuo}
                   id="apf-is-duo"
                   label="Accepter les réservations DUO"
                   name="isDuo"
@@ -118,36 +122,71 @@ const AllocineProviderForm = ({ createVenueProvider, providerId, venueId }) => {
                 <br />
                 Nous travaillons actuellement à l’ajout de séances spécifiques.
               </Insert>
-
-              <div className="apf-provider-import-button-section">
-                <button
-                  className="primary-button"
-                  disabled={!canSubmit}
-                  onClick={formProps.handleSubmit}
-                  type="submit"
-                >
-                  Importer les offres
-                </button>
-              </div>
+              {isCreatedEntity ? (
+                <div className="apf-provider-import-button-section">
+                  <button
+                    className="primary-button"
+                    disabled={!canSubmit}
+                    onClick={formProps.handleSubmit}
+                    type="submit"
+                  >
+                    Importer les offres
+                  </button>
+                </div>
+              ): (
+                <div className="actions">
+                  <button
+                    className="secondary-button"
+                    onClick={onCancel}
+                    type="button"
+                  >
+                    Annuler
+                  </button>
+                  <button
+                    className="primary-button"
+                    disabled={!canSubmit}
+                    onClick={formProps.handleSubmit}
+                    type="submit"
+                  >
+                    Modifier
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </form>
       )
     },
-    [isLoading, required]
+    [isCreatedEntity, isLoading, onCancel, required]
   )
 
   return (
     <Form
+      initialValues={initialValues}
       onSubmit={handleSubmit}
       render={renderForm}
     />
   )
 }
 
+AllocineProviderForm.defaultProps = {
+  initialValues: {
+    isDuo: true
+  },
+  isCreatedEntity: false,
+  onCancel: () => {}
+}
+
 AllocineProviderForm.propTypes = {
-  createVenueProvider: PropTypes.func.isRequired,
+  initialValues: PropTypes.shape({
+    isDuo: PropTypes.bool,
+    price: PropTypes.number,
+    quantity: PropTypes.number
+  }),
+  isCreatedEntity: PropTypes.bool,
+  onCancel: PropTypes.func,
   providerId: PropTypes.string.isRequired,
+  saveVenueProvider: PropTypes.func.isRequired,
   venueId: PropTypes.string.isRequired,
 }
 

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderFormDialog/AllocineProviderFormDialog.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderFormDialog/AllocineProviderFormDialog.jsx
@@ -1,0 +1,48 @@
+import PropTypes from "prop-types"
+import React from 'react'
+
+import {DialogBox} from "components/layout/DialogBox/DialogBox"
+
+import AllocineProviderForm from "../AllocineProviderForm/AllocineProviderForm"
+import './AllocineProviderFormDialog.scss'
+
+const AllocineProviderFormDialog = ({onCancel, onConfirm, initialValues, providerId, venueId}) => {
+  return (
+    <DialogBox
+      extraClassNames="allocine-provider-form-dialog"
+      labelledBy="allocine-provider-form-dialog"
+      onDismiss={onCancel}
+    >
+      <div className="title">
+        <strong>
+          Modifier mes offres
+        </strong>
+      </div>
+      <div className="explanation">
+        Les modifications s’appliqueront uniquement aux nouvelles offres créées. La modification doit être faite manuellement pour les offres existantes
+      </div>
+      <AllocineProviderForm
+        initialValues={initialValues}
+        onCancel={onCancel}
+        providerId={providerId}
+        saveVenueProvider={onConfirm}
+        venueId={venueId}
+      />
+
+    </DialogBox>
+  )
+}
+
+AllocineProviderFormDialog.propTypes = {
+  initialValues: PropTypes.shape({
+    price: PropTypes.number.isRequired,
+    quantity: PropTypes.number.isRequired,
+    isDuo: PropTypes.bool.isRequired
+  }).isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  providerId: PropTypes.string.isRequired,
+  venueId: PropTypes.string.isRequired
+}
+
+export default AllocineProviderFormDialog

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderFormDialog/AllocineProviderFormDialog.scss
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderFormDialog/AllocineProviderFormDialog.scss
@@ -1,0 +1,42 @@
+.allocine-provider-form-dialog {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: rem(504px);
+  text-align: left;
+
+  .title {
+    @include gabarit();
+  }
+
+  .explanation {
+    margin-top: rem(24px);
+  }
+
+  .allocine-provider-form {
+    margin-top: rem(32px);
+
+    input[type=number] {
+      height: rem(40px);
+    }
+
+    .imported-offres-clarification {
+      @include caption();
+
+      color: $grey-dark;
+      margin-top: rem(24px);
+    }
+
+    .actions {
+      display: flex;
+      justify-content: center;
+      margin-top: rem(40px);
+
+      button {
+        margin: 0 rem(16px);
+        padding: 0 rem(80px);
+      }
+    }
+  }
+}

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/AllocineProviderItem.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/AllocineProviderItem.jsx
@@ -1,0 +1,101 @@
+import PropTypes from "prop-types"
+import React, {useCallback, useState} from 'react'
+
+import AllocineProviderFormDialog from "../AllocineProviderFormDialog/AllocineProviderFormDialog"
+import VenueProviderItem from "../VenueProviderItem/VenueProviderItem"
+
+const AllocineProviderItem = ({venueProvider, venueDepartmentCode, editVenueProvider}) => {
+  const [isOpenedFormDialog, setIsOpenedFormDialog] = useState(false)
+
+  const openFormDialog = useCallback(() => {
+    setIsOpenedFormDialog(true)
+  }, [])
+
+  const closeFormDialog = useCallback(() => {
+    setIsOpenedFormDialog(false)
+  }, [])
+
+  const onConfirmDialog = useCallback((payload) => {
+    editVenueProvider(payload)
+
+    closeFormDialog()
+  }, [closeFormDialog, editVenueProvider])
+
+  const initialValues = {
+    price: venueProvider.price,
+    quantity: venueProvider.quantity,
+    isDuo: venueProvider.isDuo
+  }
+
+  return (
+    <VenueProviderItem
+      venueDepartmentCode={venueDepartmentCode}
+      venueProvider={venueProvider}
+    >
+      <>
+        <li>
+          <span>
+            {'Prix de vente/place : '}
+          </span>
+          <span>
+            {`${new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(
+              venueProvider.price
+            )}`}
+          </span>
+        </li>
+        <li>
+          <span>
+            {'Nombre de places/séance : '}
+          </span>
+          <span>
+            {`${venueProvider.quantity ? venueProvider.quantity : 'Illimité'}`}
+          </span>
+        </li>
+        <li>
+          <span>
+            {'Accepter les offres DUO : '}
+          </span>
+          <span>
+            {`${venueProvider.isDuo ? 'Oui' : 'Non'} `}
+          </span>
+        </li>
+        <button
+          className="primary-button"
+          onClick={openFormDialog}
+          type="button"
+        >
+          Modifier les paramètres
+        </button>
+        {isOpenedFormDialog && (
+          <AllocineProviderFormDialog
+            initialValues={initialValues}
+            onCancel={closeFormDialog}
+            onConfirm={onConfirmDialog}
+            providerId={venueProvider.providerId}
+            venueId={venueProvider.venueId}
+          />
+        )}
+      </>
+    </VenueProviderItem>
+  )
+}
+
+AllocineProviderItem.propTypes = {
+  editVenueProvider: PropTypes.func.isRequired,
+  venueDepartmentCode: PropTypes.string.isRequired,
+  venueProvider: PropTypes.shape({
+    provider: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }).isRequired,
+    providerId: PropTypes.string.isRequired,
+    venueId: PropTypes.string.isRequired,
+    lastSyncDate: PropTypes.string,
+    nOffers: PropTypes.number.isRequired,
+    venueIdAtOfferProvider: PropTypes.string,
+    price: PropTypes.number,
+    quantity: PropTypes.number,
+    isDuo: PropTypes.bool,
+  }).isRequired,
+}
+
+export default AllocineProviderItem

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/__specs__/AllocineProviderItem.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderItem/__specs__/AllocineProviderItem.spec.jsx
@@ -1,0 +1,120 @@
+import '@testing-library/jest-dom'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+
+import NotificationContainer from 'components/layout/Notification/NotificationContainer'
+import * as pcapi from 'repository/pcapi/pcapi'
+import { configureTestStore } from 'store/testUtils'
+import { queryByTextTrimHtml } from 'utils/testHelpers'
+
+import VenueProvidersManagerContainer from '../../VenueProvidersManagerContainer'
+
+jest.mock('repository/pcapi/pcapi', () => ({
+  createVenueProvider: jest.fn(),
+  loadProviders: jest.fn(),
+  loadVenueProviders: jest.fn(),
+}))
+
+const renderVenueProvidersManager = async props => {
+  await act(async () => {
+    await render(
+      <Provider store={configureTestStore()}>
+        <MemoryRouter>
+          <VenueProvidersManagerContainer {...props} />
+          <NotificationContainer />
+        </MemoryRouter>
+      </Provider>
+    )
+  })
+}
+
+describe('src | components | pages | Venue | VenueProvidersManager | AllocineProviderItem', () => {
+  let props
+  let allocineVenueProvider
+
+  beforeEach(async () => {
+    const venue = {
+      id: 'venueId',
+      managingOffererId: 'managingOffererId',
+      name: 'Le lieu',
+      siret: '12345678901234',
+      departementCode: '75',
+    }
+    allocineVenueProvider = {
+      id: 'venueProviderId',
+      isActive: true,
+      isDuo: true,
+      lastSyncDate: '2018-01-01T00:00:00Z',
+      nOffers: 35,
+      price: 10.1,
+      provider: {
+        name: 'Allociné',
+      },
+      quantity: 30,
+      venueId: venue.id,
+      venueIdAtOfferProvider: 'venueIdAtOfferProvider',
+    }
+
+    props = {
+      venue,
+    }
+
+    pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
+    pcapi.loadProviders.mockResolvedValue([])
+  })
+
+  it('should show synchronization modalities when venue provider is allocine', async () => {
+    // given
+    pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
+
+    // when
+    await renderVenueProvidersManager(props)
+
+    // then
+    const price = queryByTextTrimHtml(screen, `Prix de vente/place : 10,10`)
+    expect(price).toBeInTheDocument()
+    const quantity = queryByTextTrimHtml(
+      screen,
+      `Nombre de places/séance : ${allocineVenueProvider.quantity}`
+    )
+    expect(quantity).toBeInTheDocument()
+    const isDuo = queryByTextTrimHtml(
+      screen,
+      `Accepter les offres DUO : ${allocineVenueProvider.isDuo ? 'Oui' : 'Non'}`
+    )
+    expect(isDuo).toBeInTheDocument()
+  })
+
+  it('should show the last synchronization date', async () => {
+    // given
+    pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
+
+    // when
+    await renderVenueProvidersManager(props)
+    const lastSyncDate = screen.getByTestId('last-sync-date')
+
+    // then
+    /*eslint-disable-next-line no-irregular-whitespace*/
+    expect(lastSyncDate.textContent).toMatchInlineSnapshot(`" 01/01/2018 à 01:00"`)
+  })
+
+  it('should show edit button and open edit dialog when it clicked', async () => {
+    // given
+    pcapi.loadProviders.mockResolvedValue([allocineVenueProvider])
+
+    // when
+    await renderVenueProvidersManager(props)
+
+    // then
+    const editAllocineProviderButton = screen.getByText('Modifier les paramètres')
+    expect(editAllocineProviderButton).toBeInTheDocument()
+
+    // when
+    fireEvent.click(editAllocineProviderButton)
+
+    // then
+    expect(screen.getByText('Modifier mes offres')).toBeInTheDocument()
+  })
+})

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/StocksProviderForm/StocksProviderForm.jsx
@@ -10,7 +10,7 @@ import Spinner from 'components/layout/Spinner'
 
 import ConfirmDialog from '../ConfirmDialog/ConfirmDialog'
 
-const StocksProviderForm = ({ createVenueProvider, providerId, siret, venueId }) => {
+const StocksProviderForm = ({ saveVenueProvider, providerId, siret, venueId }) => {
   const [isCheckingApi, setIsCheckingApi] = useState(false)
   const [isConfirmDialogOpened, setIsConfirmDialogOpened] = useState(false)
 
@@ -32,9 +32,9 @@ const StocksProviderForm = ({ createVenueProvider, providerId, siret, venueId })
       venueId,
     }
 
-    createVenueProvider(payload)
+    saveVenueProvider(payload)
     setIsConfirmDialogOpened(false)
-  }, [createVenueProvider, providerId, siret, venueId])
+  }, [saveVenueProvider, providerId, siret, venueId])
 
   if (isCheckingApi) {
     return <Spinner message="Vérification de votre rattachement" />
@@ -74,8 +74,8 @@ const StocksProviderForm = ({ createVenueProvider, providerId, siret, venueId })
 }
 
 StocksProviderForm.propTypes = {
-  createVenueProvider: PropTypes.func.isRequired,
   providerId: PropTypes.string.isRequired,
+  saveVenueProvider: PropTypes.func.isRequired,
   siret: PropTypes.string.isRequired,
   venueId: PropTypes.string.isRequired,
 }

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/VenueProviderItem.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/VenueProviderItem.jsx
@@ -14,7 +14,7 @@ import { isAllocineProvider } from 'components/pages/Offers/domain/localProvider
 import { pluralize } from 'utils/pluralize'
 import { formatLocalTimeDateString } from 'utils/timezone'
 
-const VenueProviderItem = ({ venueProvider, venueDepartmentCode }) => {
+const VenueProviderItem = ({ venueProvider, venueDepartmentCode, children }) => {
   const { lastSyncDate, nOffers, provider, venueIdAtOfferProvider } = venueProvider
   const providerInfo = getProviderInfo(provider.name)
   const shouldDisplayProviderInformations = isAllocineProvider(provider) || lastSyncDate
@@ -87,37 +87,7 @@ const VenueProviderItem = ({ venueProvider, venueDepartmentCode }) => {
                 </span>
               </li>
             )}
-            {isAllocineProvider(provider) && (
-              <>
-                <li>
-                  <span>
-                    {'Prix de vente/place : '}
-                  </span>
-                  <span>
-                    {`${new Intl.NumberFormat('fr-FR', {
-                      style: 'currency',
-                      currency: 'EUR',
-                    }).format(venueProvider.price)}`}
-                  </span>
-                </li>
-                <li>
-                  <span>
-                    {'Nombre de places/séance : '}
-                  </span>
-                  <span>
-                    {`${venueProvider.quantity ? venueProvider.quantity : 'Illimité'}`}
-                  </span>
-                </li>
-                <li>
-                  <span>
-                    {'Accepter les offres DUO : '}
-                  </span>
-                  <span>
-                    {`${venueProvider.isDuo ? 'Oui' : 'Non'} `}
-                  </span>
-                </li>
-              </>
-            )}
+            {children}
           </ul>
         </div>
       )}
@@ -125,7 +95,12 @@ const VenueProviderItem = ({ venueProvider, venueDepartmentCode }) => {
   )
 }
 
+VenueProviderItem.defaultProps = {
+  children: null
+}
+
 VenueProviderItem.propTypes = {
+  children: PropTypes.node,
   venueDepartmentCode: PropTypes.string.isRequired,
   venueProvider: PropTypes.shape({
     provider: PropTypes.shape({
@@ -134,9 +109,6 @@ VenueProviderItem.propTypes = {
     lastSyncDate: PropTypes.string,
     nOffers: PropTypes.number.isRequired,
     venueIdAtOfferProvider: PropTypes.string,
-    price: PropTypes.number,
-    quantity: PropTypes.number,
-    isDuo: PropTypes.bool,
   }).isRequired,
 }
 

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/VenueProviderItem.scss
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/VenueProviderItem.scss
@@ -95,5 +95,10 @@
         color: $grey-dark;
       }
     }
+
+    button {
+      margin-top: rem(32px);
+      padding: 0 rem(32px);
+    }
   }
 }

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/__specs__/VenueProviderItem.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProviderItem/__specs__/VenueProviderItem.spec.jsx
@@ -1,7 +1,7 @@
 /*
-* @debt complexity "Gaël: file nested too deep in directory structure"
-* @debt rtl "Gaël: bad use of act in testing library"
-*/
+ * @debt complexity "Gaël: file nested too deep in directory structure"
+ * @debt rtl "Gaël: bad use of act in testing library"
+ */
 
 import '@testing-library/jest-dom'
 import { act, render, screen } from '@testing-library/react'
@@ -38,7 +38,6 @@ const renderVenueProvidersManager = async props => {
 describe('src | components | pages | Venue | VenueProvidersManager | VenueProviderItem', () => {
   let props
   let titeliveVenueProvider
-  let allocineVenueProvider
 
   beforeEach(async () => {
     const venue = {
@@ -56,20 +55,6 @@ describe('src | components | pages | Venue | VenueProvidersManager | VenueProvid
       provider: {
         name: 'TiteLive',
       },
-      venueId: venue.id,
-      venueIdAtOfferProvider: 'venueIdAtOfferProvider',
-    }
-    allocineVenueProvider = {
-      id: 'venueProviderId',
-      isActive: true,
-      isDuo: true,
-      lastSyncDate: '2018-01-01T00:00:00Z',
-      nOffers: 35,
-      price: 10.1,
-      provider: {
-        name: 'Allociné',
-      },
-      quantity: 30,
       venueId: venue.id,
       venueIdAtOfferProvider: 'venueIdAtOfferProvider',
     }
@@ -141,31 +126,9 @@ describe('src | components | pages | Venue | VenueProvidersManager | VenueProvid
     expect(numberOfOffersLabel).toBeInTheDocument()
   })
 
-  it('should show synchronization modalities when venue provider is allocine', async () => {
-    // given
-    pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
-
-    // when
-    await renderVenueProvidersManager(props)
-
-    // then
-    const price = queryByTextTrimHtml(screen, `Prix de vente/place : 10,10`)
-    expect(price).toBeInTheDocument()
-    const quantity = queryByTextTrimHtml(
-      screen,
-      `Nombre de places/séance : ${allocineVenueProvider.quantity}`
-    )
-    expect(quantity).toBeInTheDocument()
-    const isDuo = queryByTextTrimHtml(
-      screen,
-      `Accepter les offres DUO : ${allocineVenueProvider.isDuo ? 'Oui' : 'Non'}`
-    )
-    expect(isDuo).toBeInTheDocument()
-  })
-
   it('should show the last synchronization date', async () => {
     // given
-    pcapi.loadVenueProviders.mockResolvedValue([allocineVenueProvider])
+    pcapi.loadVenueProviders.mockResolvedValue([titeliveVenueProvider])
 
     // when
     await renderVenueProvidersManager(props)

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
@@ -12,6 +12,7 @@ import { ReactComponent as AddOfferSvg } from 'icons/ico-plus.svg'
 import * as pcapi from 'repository/pcapi/pcapi'
 
 import AllocineProviderForm from './AllocineProviderForm/AllocineProviderForm'
+import AllocineProviderItem from "./AllocineProviderItem/AllocineProviderItem"
 import StocksProviderForm from './StocksProviderForm/StocksProviderForm'
 import { DEFAULT_PROVIDER_OPTION } from './utils/_constants'
 import VenueProviderItem from './VenueProviderItem/VenueProviderItem'
@@ -77,6 +78,18 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
     [cancelProviderSelection, notifyError, notifySuccess, isAllocineProviderSelected]
   )
 
+  const editVenueProvider = useCallback(
+    payload => {
+      pcapi
+        .editVenueProvider(payload)
+        .then(editedVenueProvider => {
+          const newVenueProviders = venueProviders.map(venueProvider => venueProvider.id === editedVenueProvider.id ? editedVenueProvider : venueProvider)
+          setVenueProviders(newVenueProviders)
+        })
+    },
+    [venueProviders]
+  )
+
   const hasAtLeastOneProvider = providers.length > 0
   const hasNoVenueProvider = venueProviders.length === 0
 
@@ -90,11 +103,21 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
 
       <ul className="provider-list">
         {venueProviders.map(venueProvider => (
-          <VenueProviderItem
-            key={venueProvider.id}
-            venueDepartmentCode={venue.departementCode}
-            venueProvider={venueProvider}
-          />
+          isAllocineProvider(venueProvider.provider) ? (
+            <AllocineProviderItem
+              editVenueProvider={editVenueProvider}
+              key={venueProvider.id}
+              venueDepartmentCode={venue.departementCode}
+              venueProvider={venueProvider}
+            />
+          )
+            : (
+              <VenueProviderItem
+                key={venueProvider.id}
+                venueDepartmentCode={venue.departementCode}
+                venueProvider={venueProvider}
+              />
+              )
         ))}
       </ul>
 
@@ -111,14 +134,15 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
           {selectedProviderId !== DEFAULT_PROVIDER_OPTION.id &&
             (isAllocineProviderSelected ? (
               <AllocineProviderForm
-                createVenueProvider={createVenueProvider}
+                isCreatedEntity
                 providerId={selectedProviderId}
+                saveVenueProvider={createVenueProvider}
                 venueId={venue.id}
               />
             ) : (
               <StocksProviderForm
-                createVenueProvider={createVenueProvider}
                 providerId={selectedProviderId}
+                saveVenueProvider={createVenueProvider}
                 siret={venue.siret}
                 venueId={venue.id}
               />

--- a/src/repository/pcapi/pcapi.js
+++ b/src/repository/pcapi/pcapi.js
@@ -248,6 +248,10 @@ export const createVenueProvider = async venueProvider => {
   return client.post('/venueProviders', venueProvider)
 }
 
+export const editVenueProvider = async venueProvider => {
+  return client.put('/venueProviders', venueProvider)
+}
+
 export const loadProviders = async venueId => {
   return client.get(`/providers/${venueId}`)
 }


### PR DESCRIPTION
**Objectif :** Permettre aux acteurs PRO de modifier les paramètres d'import des offres Allociné (prix, quantité, offres duo)

**Implémentation :** 
 - Ajout d'un nouveau composant `AllocineProviderItem` composé de `VenueProviderItem`.
 - Ajout d'une modale pour afficher le formulaire d'édition de paramètres.
 - Modification du composant `AllocineProviderForm` pour l'utilisation en création ou édition. 
 - Tests