### PR TITLE
(PC-8558): display toaster when edited venue provide is saved

### DIFF
--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
@@ -359,5 +359,63 @@ describe('components | AllocineProviderForm', () => {
         venueId: props.venue.id,
       })
     })
+
+    it('should display a success notification when venue provider was correctly updated', async () => {
+      // given
+      allocineProvider = {
+        ...allocineProvider,
+        price: 15,
+        quantity: 50,
+        isDuo: false
+      }
+      pcapi.loadVenueProviders.mockResolvedValue([allocineProvider])
+      const editedAllocineProvider = {
+        ...allocineProvider,
+        price: 20,
+        quantity: 50,
+        isDuo: false
+      }
+      pcapi.editVenueProvider.mockResolvedValue(editedAllocineProvider)
+
+      await renderAllocineProviderForm()
+      const saveEditioProvider = screen.getByRole('button', { name: 'Modifier' })
+      const priceField = screen.getByLabelText('Prix de vente/place', { exact: false })
+
+      fireEvent.change(priceField, { target: { value: 10 } })
+
+      // when
+      fireEvent.click(saveEditioProvider)
+
+      // then
+      const successNotification = await screen.findByText('Les modifications ont bien été importées et s’appliqueront aux nouvelles séances créées.')
+      expect(successNotification).toBeInTheDocument()
+    })
+
+    it('should display an error notification if there is something wrong with the server', async () => {
+      // given
+      const editedAllocineProvider = {
+        ...allocineProvider,
+        price: 20,
+        quantity: 50,
+        isDuo: false
+      }
+      pcapi.editVenueProvider.mockResolvedValue(editedAllocineProvider)
+      const apiError = {
+        errors: { global: ['Le prix ne peut pas être négatif'] },
+        status: 400,
+      }
+      pcapi.editVenueProvider.mockRejectedValue(apiError)
+      await renderAllocineProviderForm()
+      const saveEditioProvider = screen.getByRole('button', { name: 'Modifier' })
+      const priceField = screen.getByLabelText('Prix de vente/place', { exact: false })
+
+      // when
+      fireEvent.change(priceField, { target: { value: -10 } })
+      await fireEvent.click(saveEditioProvider)
+
+      // then
+      const errorNotification = await screen.findByText(apiError.errors.global[0])
+      expect(errorNotification).toBeInTheDocument()
+    })
   })
 })

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
@@ -66,7 +66,7 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
         .then(createdVenueProvider => {
           setVenueProviders([createdVenueProvider])
           setIsCreationMode(false)
-          notifySuccess()
+          notifySuccess("La synchronisation a bien été initiée.")
         })
         .catch(error => {
           notifyError(error.errors)
@@ -85,9 +85,13 @@ const VenueProvidersManagerContainer = ({ notifyError, notifySuccess, venue }) =
         .then(editedVenueProvider => {
           const newVenueProviders = venueProviders.map(venueProvider => venueProvider.id === editedVenueProvider.id ? editedVenueProvider : venueProvider)
           setVenueProviders(newVenueProviders)
+          notifySuccess("Les modifications ont bien été importées et s’appliqueront aux nouvelles séances créées.")
+        })
+        .catch(error => {
+          notifyError(error.errors)
         })
     },
-    [venueProviders]
+    [notifyError, notifySuccess, venueProviders]
   )
 
   const hasAtLeastOneProvider = providers.length > 0

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManagerContainer.js
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManagerContainer.js
@@ -19,10 +19,10 @@ const mapDispatchToProps = dispatch => ({
       })
     )
   },
-  notifySuccess: () => {
+  notifySuccess: (message) => {
     dispatch(
       showNotification({
-        text: 'La synchronisation a bien été initiée.',
+        text: message,
         type: 'success',
       })
     )


### PR DESCRIPTION
**Objectifs :** Afficher le toaster de succès s’affiche “Les modifications ont bien été importées et s’appliqueront aux nouvelles séances créées.” après l'édition de allociné provider.