### PR TITLE
(PC-8558): Venue prodvider creation/edition not send quantity when it value is empty

### DIFF
--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.jsx
@@ -25,7 +25,8 @@ const AllocineProviderForm = ({ saveVenueProvider, providerId, venueId, isCreate
 
   const handleSubmit = useCallback(
     formValues => {
-      const { quantity, isDuo = true, price } = formValues
+      const { isDuo = true, price } = formValues
+      const quantity = formValues.quantity !== '' ? formValues.quantity : null
 
       const payload = {
         quantity,

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.jsx
@@ -360,6 +360,43 @@ describe('components | AllocineProviderForm', () => {
       })
     })
 
+    it('should not send quantity when it value is removed', async () => {
+      // given
+      allocineProvider = {
+        ...allocineProvider,
+        price: 20,
+        quantity: 50,
+        isDuo: false
+      }
+      pcapi.loadVenueProviders.mockResolvedValue([allocineProvider])
+      const editedAllocineProvider = {
+        ...allocineProvider,
+        price: 20,
+        quantity: null,
+        isDuo: false
+      }
+
+      pcapi.editVenueProvider.mockResolvedValue(editedAllocineProvider)
+
+      await renderAllocineProviderForm()
+
+      const saveEditioProvider = screen.getByRole('button', { name: 'Modifier' })
+      const quantityField = screen.getByLabelText('Nombre de places/séance')
+
+      // when
+      fireEvent.change(quantityField, { target: { value: '' } })
+      fireEvent.click(saveEditioProvider)
+
+      // then
+      expect(pcapi.editVenueProvider).toHaveBeenCalledWith({
+        price: editedAllocineProvider.price,
+        quantity: editedAllocineProvider.quantity,
+        isDuo: editedAllocineProvider.isDuo,
+        providerId: provider.id,
+        venueId: props.venue.id,
+      })
+    })
+
     it('should display a success notification when venue provider was correctly updated', async () => {
       // given
       allocineProvider = {


### PR DESCRIPTION
** Objectifs :** Création/Edition Venue provider, Nne pas envoyer une chaîne de caractère vide pour l'attribut `quantity` lorsque l'utilisateur supprime la valeur initiale.