### PR TITLE
[BSR] testcafe: wait for front end server response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
+            dockerize -wait http://localhost:3001 -timeout 5m -wait-retry-interval 5s
             yarn test:cafe
       - store_artifacts:
          path: ~/pass-culture-main/pro/testcafe_screenshots


### PR DESCRIPTION
Le premier test café timeout.
```
Failed to load the page at "http://localhost:3001/inscription".
      Increase the value of the "pageRequestTimeout" variable, enable the
      "retryTestPages" option, or use quarantine mode to perform
      additional attempts to execute this test.
      You can find troubleshooting information for this issue at
      "https://go.devexpress.com/TestCafe_FAQ_ARequestHasFailed.aspx".
```

Il semble que la nouvelle configuration webpack soit tres longue à s'initialiser, on se retrouve avec le server de pro qui n'est pas up lorsque les testcafe commencent.

Il semble que ce fix du 1er test ne soit pas suffisant, suite à ce commit nous nous retrouvons avec deux autres test cassé sur l'erreur suivante:
```
JavaScript error details:
      TypeError: Cannot convert undefined or null to object
          at Function.keys (<anonymous>)
          at Desk.firstErrorMessageFromApi
      (http://localhost:3001/static/js/main.chunk.js:19735:52)
          at Desk.getErrorMessageFromApi
      (http://localhost:3001/static/js/main.chunk.js:19738:29)
          at http://localhost:3001/static/js/main.chunk.js:19780:37
```
`Desk.firstErrorMessageFromApi` vas parser le retour de l'erreur api dans un 
```javascript
api.myApiCall()
  .then()
  .catch((error) => Desk.firstErrorMessageFromApi(error.myErrorsObjectKey)
```
L'erreur levé par la method api ici ne contient pas l'object d'erreur, je pense qu'on à a nouveau un timeout.
