### PR TITLE
(PC-10982) circleci: don't fail if codecov or coveralls fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,8 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
             yarn test:unit --coverage --silent
-            yarn coveralls
-            bash <(curl -s https://codecov.io/bash)
+            yarn coveralls || echo "Encountered an error while running coveralls"
+            bash <(curl -s https://codecov.io/bash) || echo "Encountered an error while uploading to codecov"
 
   e2e-tests:
     machine:


### PR DESCRIPTION
There has been a service incident on coveralls.io for several days which prevents the rest of the workflow to complete, so we'll catch exceptions during the coverio and coveralls parts of the `unit-tests` job