### PR TITLE
Rlecellier/pc 10266 accessibility autofill offer

### DIFF
--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/AccessibilityCheckboxList/AccessibilityCheckboxList.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/AccessibilityCheckboxList/AccessibilityCheckboxList.jsx
@@ -8,43 +8,50 @@ import { ReactComponent as MentalDisabilitySvg } from 'icons/mental-disability.s
 import { ReactComponent as MotorDisabilitySvg } from 'icons/motor-disability.svg'
 import { ReactComponent as VisualDisabilitySvg } from 'icons/visual-disability.svg'
 
-const autoFillValues = function (formValues, field, value) {
-  let disabilityCompliantValues = {
-    noDisabilityCompliant: formValues.noDisabilityCompliant,
-    audioDisabilityCompliant: formValues.audioDisabilityCompliant,
-    mentalDisabilityCompliant: formValues.mentalDisabilityCompliant,
-    motorDisabilityCompliant: formValues.motorDisabilityCompliant,
-    visualDisabilityCompliant: formValues.visualDisabilityCompliant,
+
+export const getDisabilityComplianceValues = values => ({
+  audioDisabilityCompliant: values.audioDisabilityCompliant,
+  mentalDisabilityCompliant: values.mentalDisabilityCompliant,
+  motorDisabilityCompliant: values.motorDisabilityCompliant,
+  visualDisabilityCompliant: values.visualDisabilityCompliant,
+})
+
+const checkHasNoDisabilityCompliance = disabilityComplianceValues => {
+  const hasNull = Object.values(disabilityComplianceValues).includes(null)
+  const hasUndefined = Object.values(disabilityComplianceValues).includes(undefined)
+  if (hasNull || hasUndefined) {
+    return null
   }
 
-  disabilityCompliantValues[field] = value
+  return !Object.values(disabilityComplianceValues).includes(true)
+}
+
+const autoFillValues = function (formValues, field, value) {
+  let noDisabilityCompliant = formValues.noDisabilityCompliant
+  let disabilityCompliantValues = getDisabilityComplianceValues(formValues)
+  // normalize null value as false
+  disabilityCompliantValues = Object.keys(disabilityCompliantValues).reduce(
+    (acc, field) => ({ ...acc, [field]: !!disabilityCompliantValues[field] }),
+    {}
+  )
 
   if (field === 'noDisabilityCompliant') {
-    if (disabilityCompliantValues[field]) {
-      disabilityCompliantValues.audioDisabilityCompliant = false
-      disabilityCompliantValues.mentalDisabilityCompliant = false
-      disabilityCompliantValues.motorDisabilityCompliant = false
-      disabilityCompliantValues.visualDisabilityCompliant = false
-    } else {
-      const hasNoDisabilityCompliance = ![
-        disabilityCompliantValues.audioDisabilityCompliant,
-        disabilityCompliantValues.mentalDisabilityCompliant,
-        disabilityCompliantValues.motorDisabilityCompliant,
-        disabilityCompliantValues.visualDisabilityCompliant,
-      ].includes(true)
-      if (hasNoDisabilityCompliance) {
-        disabilityCompliantValues[field] = true
-      }
+    noDisabilityCompliant = value
+
+    if (noDisabilityCompliant) {
+      disabilityCompliantValues = Object.keys(disabilityCompliantValues).reduce(
+        (acc, field) => ({ ...acc, [field]: false }),
+        {}
+      )
+    } else if (!Object.values(disabilityCompliantValues).includes(true)) {
+      noDisabilityCompliant = true
     }
   } else {
-    if (Object.values(disabilityCompliantValues).includes(true)) {
-      disabilityCompliantValues.noDisabilityCompliant = false
-    } else {
-      disabilityCompliantValues.noDisabilityCompliant = true
-    }
+    disabilityCompliantValues[field] = value
+    noDisabilityCompliant = checkHasNoDisabilityCompliance(disabilityCompliantValues)
   }
 
-  return disabilityCompliantValues
+  return { ...disabilityCompliantValues, noDisabilityCompliant }
 }
 
 const AccessibilityCheckboxList = ({ onChange, formValues, isInError, isDisabled, readOnly }) => {

--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/AccessibilityCheckboxList/index.ts
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/AccessibilityCheckboxList/index.ts
@@ -1,1 +1,1 @@
-export { default } from './AccessibilityCheckboxList'
+export { default, getDisabilityComplianceValues } from './AccessibilityCheckboxList'

--- a/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferEdition.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/OfferForm/OfferEdition.jsx
@@ -1,7 +1,7 @@
 /*
-* @debt complexity "Gaël: file nested too deep in directory structure"
-* @debt directory "Gaël: this file should be migrated within the new directory structure"
-*/
+ * @debt complexity "Gaël: file nested too deep in directory structure"
+ * @debt directory "Gaël: this file should be migrated within the new directory structure"
+ */
 
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
@@ -16,9 +16,11 @@ import {
   DEFAULT_FORM_VALUES,
   EDITED_OFFER_READ_ONLY_FIELDS,
 } from 'components/pages/Offers/Offer/OfferDetails/OfferForm/_constants'
+import { getDisabilityComplianceValues } from 'components/pages/Offers/Offer/OfferDetails/OfferForm/AccessibilityCheckboxList'
 import { computeOffersUrl } from 'components/pages/Offers/utils/computeOffersUrl'
 
 import OfferForm from './OfferForm'
+
 
 const computeNoDisabilityComplianceValue = offer => {
   const disabilityCompliantValues = [
@@ -30,8 +32,7 @@ const computeNoDisabilityComplianceValue = offer => {
 
   const unknownDisabilityCompliance = disabilityCompliantValues.includes(null)
   const hasDisabilityCompliance = disabilityCompliantValues.includes(true)
-
-  if (unknownDisabilityCompliance || hasDisabilityCompliance) {
+  if (hasDisabilityCompliance || unknownDisabilityCompliance) {
     return false
   }
 
@@ -61,7 +62,7 @@ const OfferEdition = ({
 
   useEffect(() => {
     const computeInitialValues = offer => {
-      const initialValues = Object.keys(DEFAULT_FORM_VALUES).reduce((acc, field) => {
+      let initialValues = Object.keys(DEFAULT_FORM_VALUES).reduce((acc, field) => {
         if (field in offer && offer[field] !== null) {
           return { ...acc, [field]: offer[field] }
         } else if (offer.extraData && field in offer.extraData) {
@@ -69,6 +70,15 @@ const OfferEdition = ({
         }
         return { ...acc, [field]: DEFAULT_FORM_VALUES[field] }
       }, {})
+      
+      const offerAccessibility = getDisabilityComplianceValues(offer)
+      const venueAccessibility = getDisabilityComplianceValues(offer.venue)
+      if (
+        Object.values(offerAccessibility).includes(null) 
+        && !Object.values(venueAccessibility).includes(null)
+      ) {
+        initialValues = { ...initialValues, ...venueAccessibility }
+      }
 
       initialValues.categoryId = subCategories.find(
         subCategory => subCategory.id === offer.subcategoryId

--- a/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
+++ b/src/components/pages/Offers/Offer/OfferDetails/__specs__/OfferCreationForPro.spec.jsx
@@ -22,7 +22,6 @@ import { queryByTextTrimHtml } from 'utils/testHelpers'
 import OfferLayoutContainer from '../../OfferLayoutContainer'
 
 import {
-  fieldLabels,
   findInputErrorForField,
   getOfferInputForField,
   queryInputErrorForField,
@@ -121,6 +120,10 @@ describe('offerDetails - Creation - pro user', () => {
         offererName: "L'autre structure",
         bookingEmail: 'autre-lieu@example.com',
         withdrawalDetails: 'Modalité retrait 2',
+        audioDisabilityCompliant: true,
+        mentalDisabilityCompliant: true,
+        motorDisabilityCompliant: true,
+        visualDisabilityCompliant: true,
       },
       {
         id: 'ABCD',
@@ -1366,46 +1369,76 @@ describe('offerDetails - Creation - pro user', () => {
         await setOfferValues({ categoryId: 'LIVRE' })
         await setOfferValues({ subcategoryId: 'LIVRE_PAPIER', venueId: venues[0].id })
 
-        // Then
-        const audioDisabilityCompliantCheckbox = screen.getByLabelText(
-          fieldLabels.audioDisabilityCompliant.label,
-          {
-            exact: fieldLabels.audioDisabilityCompliant.exact,
-          }
-        )
-        expect(audioDisabilityCompliantCheckbox).not.toBeChecked()
+        const accessibilityCheckboxes = {
+          audioDisabilityCompliant: await getOfferInputForField('audioDisabilityCompliant'),
+          mentalDisabilityCompliant: await getOfferInputForField('mentalDisabilityCompliant'),
+          motorDisabilityCompliant: await getOfferInputForField('motorDisabilityCompliant'),
+          visualDisabilityCompliant: await getOfferInputForField('visualDisabilityCompliant'),
+          noDisabilityCompliant: await getOfferInputForField('noDisabilityCompliant'),
+        }
 
-        const mentalDisabilityCompliantCheckbox = screen.getByLabelText(
-          fieldLabels.mentalDisabilityCompliant.label,
-          {
-            exact: fieldLabels.mentalDisabilityCompliant.exact,
-          }
-        )
-        expect(mentalDisabilityCompliantCheckbox).not.toBeChecked()
+        // initial value are empty, all values are false
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
 
-        const motorDisabilityCompliantCheckbox = screen.getByLabelText(
-          fieldLabels.motorDisabilityCompliant.label,
-          {
-            exact: fieldLabels.motorDisabilityCompliant.exact,
-          }
-        )
-        expect(motorDisabilityCompliantCheckbox).not.toBeChecked()
+        // one accessibility true, other falses
+        await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
 
-        const visualDisabilityCompliantCheckbox = screen.getByLabelText(
-          fieldLabels.visualDisabilityCompliant.label,
-          {
-            exact: fieldLabels.visualDisabilityCompliant.exact,
-          }
-        )
-        expect(visualDisabilityCompliantCheckbox).not.toBeChecked()
+        // all accessibility false, noDisabilityCompliant should be true
+        await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).toBeChecked()
 
-        const noDisabilityCompliantCheckbox = screen.getByLabelText(
-          fieldLabels.noDisabilityCompliant.label,
-          {
-            exact: fieldLabels.noDisabilityCompliant.exact,
-          }
-        )
-        expect(noDisabilityCompliantCheckbox).not.toBeChecked()
+        // again, one accessibility true, other falses
+        await fireEvent.click(accessibilityCheckboxes.audioDisabilityCompliant)
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
+
+        // click on noDisabilityCompliant should change other accessibility to false
+        await fireEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).toBeChecked()
+
+        // a second click on noDisabilityCompliant shouldn't change values
+        await fireEvent.click(accessibilityCheckboxes.noDisabilityCompliant)
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).toBeChecked()
+
+        // change venue should use venue acessibility values
+        await setOfferValues({ subcategoryId: 'LIVRE_PAPIER', venueId: venues[1].id })
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
+
+        // change to venue without accessibility set should change all values to false 
+        await setOfferValues({ subcategoryId: 'LIVRE_PAPIER', venueId: venues[0].id })
+        expect(accessibilityCheckboxes.audioDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.mentalDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.motorDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.visualDisabilityCompliant).not.toBeChecked()
+        expect(accessibilityCheckboxes.noDisabilityCompliant).not.toBeChecked()
       })
     })
 
@@ -1450,6 +1483,7 @@ describe('offerDetails - Creation - pro user', () => {
       const offerValues = {
         name: 'Ma petite offre',
         description: 'Pas si petite que ça',
+        venueId: venues[0].id,
         durationMinutes: '1:30',
         isDuo: false,
         audioDisabilityCompliant: true,
@@ -1463,7 +1497,6 @@ describe('offerDetails - Creation - pro user', () => {
           musicSubType: '502',
           performer: 'TEST PERFORMER NAME',
         },
-        venueId: venues[0].id,
         withdrawalDetails: 'À venir chercher sur place.',
       }
 


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-10266

- [x] Enlever le 's' à Accessibilités 

- [x] L’astérisque n’a pas été déplacée au niveau du titre 

- [x] Quand la case “Non accessible” est cochée au niveau du lieu, la section Accessibilité est vide à la création d’offre. 
Attendu : la case “non accessible” devrait être cochée. 

- [x] Quand je crée une offre dans un lieu depuis l’URL https://pro.testing.passculture.team/offres/creation?structure=7U&lieu=AFVA, que je choisis une catégorie numérique exemple Jeux → Jeux en ligne. La section Accessibilité est pré-rempli avec les informations du lieu en URL pourtant j’ai choisi le lieu numérique. 
Attendu : si je choisis le lieu numérique, la section accessibilité de l’offre devrait être vide. 