### PR TITLE
VenueEdition.VenueProvidersManager: venue.siret is not mandatory

### DIFF
--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AddVenueProviderButton/AddVenueProviderButton.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/AddVenueProviderButton/AddVenueProviderButton.jsx
@@ -83,7 +83,7 @@ AddVenueProviderButton.propTypes = {
   setVenueProviders: PropTypes.func.isRequired,
   venue: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    siret: PropTypes.string.isRequired,
+    siret: PropTypes.string,
   }).isRequired,
 }
 

--- a/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
+++ b/src/components/pages/Offerers/Offerer/VenueV1/VenueEdition/VenueProvidersManager/VenueProvidersManager.jsx
@@ -70,7 +70,7 @@ VenueProvidersManager.propTypes = {
   venue: PropTypes.shape({
     id: PropTypes.string.isRequired,
     managingOffererId: PropTypes.string.isRequired,
-    siret: PropTypes.string.isRequired,
+    siret: PropTypes.string,
     departementCode: PropTypes.string.isRequired,
   }).isRequired,
 }


### PR DESCRIPTION
During VenueEdition test migration, i've some errors cause of this mandatory props.

I've check with lina, we can display this "import offers" module with a venue that have no siret.